### PR TITLE
Enhance codespell support with configuration, CI workflow, and fixes

### DIFF
--- a/.codespellignore
+++ b/.codespellignore
@@ -1,12 +1,38 @@
-# Project-specific words and language tokens
+# German language tokens (project has German UI/content)
 Sie
+sie
 oder
 ist
 ue
 Ue
-puls
-linke
-shs
+alle
+als
 Fo
 bu
 BU
+unter
+vor
+finde
+offen
+# Domain-specific terms
+# VAS = Visual Analogue Scale (survey/medical instrument)
+vas
+VAS
+# ANC = Austrian NeuroCloud
+anc
+ANC
+# .sav = SPSS file format
+sav
+SAV
+# Linz = city in Austria (Graz-based project)
+Linz
+# shs = abbreviation used in project
+shs
+# ond = appears inside regex patterns (sec(ond)?s?)
+ond
+# datas = PyInstaller standard parameter name for data files
+datas
+# puls = German for "pulse" / physiological data type
+puls
+# linke = German word
+linke

--- a/.github/instructions/repo.instructions.md
+++ b/.github/instructions/repo.instructions.md
@@ -18,9 +18,9 @@ applyTo: '**'
 
 prism is a add-on to bids - it does not replace bids
 bids-standards should not be changed
-we add schmeas (like survey) that are not in bids
+we add schemas (like survey) that are not in bids
 
-it's imporatnt that bids apps still work on prism datasets
+it's important that bids apps still work on prism datasets
 
 Always activate .venv in your terminal before running any scripts.
 missing packages should be installed via the setup script NOT manually

--- a/.github/workflows/codespell.yml
+++ b/.github/workflows/codespell.yml
@@ -1,0 +1,23 @@
+# Codespell configuration is within pyproject.toml
+---
+name: Codespell
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+
+permissions:
+  contents: read
+
+jobs:
+  codespell:
+    name: Check for spelling errors
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+      - name: Codespell
+        uses: codespell-project/actions-codespell@8f01853be192eb0f849a5c7d721450e7a467c579  # v2.2

--- a/official/library/survey/survey-bfi-s.json
+++ b/official/library/survey/survey-bfi-s.json
@@ -29,7 +29,7 @@
         ],
         "Year": 2011,
         "DOI": "",
-        "Citation": "Lang, F. R., John, D., Ludtke, O., Schupp, J., & Wagner, G. G. (2011). Short assessment of the Big Five: robust accros survey methods except telephone interviewing. Behavior Research Methods, 43, 548-567.",
+        "Citation": "Lang, F. R., John, D., Ludtke, O., Schupp, J., & Wagner, G. G. (2011). Short assessment of the Big Five: robust across survey methods except telephone interviewing. Behavior Research Methods, 43, 548-567.",
         "ItemCount": 11,
         "License": {
             "en": "Freely available for research purposes (verify with original publication)",

--- a/official/library/survey/survey-nmp-q.json
+++ b/official/library/survey/survey-nmp-q.json
@@ -58,7 +58,7 @@
                 "de": "neutral"
             },
             "4": {
-                "en": "somehwat agree",
+                "en": "somewhat agree",
                 "de": "einigermaßen zustimmen"
             },
             "5": {
@@ -99,7 +99,7 @@
                 "de": "neutral"
             },
             "4": {
-                "en": "somehwat agree",
+                "en": "somewhat agree",
                 "de": "einigermaßen zustimmen"
             },
             "5": {
@@ -140,7 +140,7 @@
                 "de": "neutral"
             },
             "4": {
-                "en": "somehwat agree",
+                "en": "somewhat agree",
                 "de": "einigermaßen zustimmen"
             },
             "5": {
@@ -181,7 +181,7 @@
                 "de": "neutral"
             },
             "4": {
-                "en": "somehwat agree",
+                "en": "somewhat agree",
                 "de": "einigermaßen zustimmen"
             },
             "5": {
@@ -222,7 +222,7 @@
                 "de": "neutral"
             },
             "4": {
-                "en": "somehwat agree",
+                "en": "somewhat agree",
                 "de": "einigermaßen zustimmen"
             },
             "5": {
@@ -263,7 +263,7 @@
                 "de": "neutral"
             },
             "4": {
-                "en": "somehwat agree",
+                "en": "somewhat agree",
                 "de": "einigermaßen zustimmen"
             },
             "5": {
@@ -304,7 +304,7 @@
                 "de": "neutral"
             },
             "4": {
-                "en": "somehwat agree",
+                "en": "somewhat agree",
                 "de": "einigermaßen zustimmen"
             },
             "5": {
@@ -345,7 +345,7 @@
                 "de": "neutral"
             },
             "4": {
-                "en": "somehwat agree",
+                "en": "somewhat agree",
                 "de": "einigermaßen zustimmen"
             },
             "5": {
@@ -386,7 +386,7 @@
                 "de": "neutral"
             },
             "4": {
-                "en": "somehwat agree",
+                "en": "somewhat agree",
                 "de": "einigermaßen zustimmen"
             },
             "5": {

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,7 +6,7 @@ exclude = '''
 
 [tool.codespell]
 # Ref: https://github.com/codespell-project/codespell#using-a-config-file
-skip = '.git,.gitignore,.gitattributes,*.pdf,*.svg,vendor,*.css,*.min.*,official,examples'
+skip = '.git,.git-meta,.gitignore,.gitattributes,*.pdf,*.svg,vendor,*.css,*.min.*,official,examples'
 check-hidden = true
 ignore-words = '.codespellignore'
 # ignore-regex = ''

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -3,3 +3,10 @@ line-length = 88
 exclude = '''
 /(\.venv|\.venv_intel|venv|build|dist|\.git|\.eggs|archive|vendor|prism\.egg-info|prism-studio\.egg-info|docs/_build)/
 '''
+
+[tool.codespell]
+# Ref: https://github.com/codespell-project/codespell#using-a-config-file
+skip = '.git,.gitignore,.gitattributes,*.pdf,*.svg,vendor,*.css,*.min.*'
+check-hidden = true
+# ignore-regex = ''
+# ignore-words-list = ''

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,7 +6,9 @@ exclude = '''
 
 [tool.codespell]
 # Ref: https://github.com/codespell-project/codespell#using-a-config-file
-skip = '.git,.gitignore,.gitattributes,*.pdf,*.svg,vendor,*.css,*.min.*'
+skip = '.git,.gitignore,.gitattributes,*.pdf,*.svg,vendor,*.css,*.min.*,official,examples'
 check-hidden = true
+ignore-words = '.codespellignore'
 # ignore-regex = ''
-# ignore-words-list = ''
+# pre-select/pre-selected are valid hyphenated forms; theses = plural of thesis
+ignore-words-list = 'theses,pre-select,pre-selected'


### PR DESCRIPTION
So there was codespell ignore file but seems no 'central' config.  There still is 

```
tests/verify_repo.py:def check_codespell(repo_path, fix=False):
```

But I think it largely becomes obsolete since better to fix config to just rely on just running `codespell` and github action would also annotate conveniently where typos found.

## Changes

### Configuration & Infrastructure
- Added `[tool.codespell]` section in `pyproject.toml` with comprehensive skip patterns
- Created GitHub Actions workflow (`.github/workflows/codespell.yml`) to check spelling on push to main and PRs
- Created `.codespellignore` file with German language tokens and domain-specific terms

### Skip Patterns
- Standard: `.git`, `.gitattributes`, `*.pdf`, `*.svg`, `vendor`, `*.css`, `*.min.*`
- Project-specific: `official/`, `examples/` (predominantly German-language survey content)

### Domain-Specific Whitelist (`.codespellignore`)
Added legitimate terms that codespell flags as typos:
- **German words**: `Sie`, `sie`, `oder`, `ist`, `als`, `unter`, `vor`, `finde`, `offen`, `alle`, `ue`/`Ue`, `Fo`, `bu`/`BU`, `linke`
- **Medical/scientific**: `VAS`/`vas` (Visual Analogue Scale), `puls` (physiological data type)
- **Project domain**: `ANC`/`anc` (Austrian NeuroCloud), `sav`/`SAV` (SPSS file format), `Linz` (city in Austria), `datas` (PyInstaller parameter name)
- **Valid English**: `theses` (plural of thesis), `pre-select`/`pre-selected` (valid hyphenated forms)

### Typo Fixes
- `schmeas` → `schemas` in `.github/instructions/repo.instructions.md`
- `imporatnt` → `important` in `.github/instructions/repo.instructions.md`
- `accros` → `across` in `official/library/survey/survey-bfi-s.json` (citation text)
- `somehwat` → `somewhat` in `official/library/survey/survey-nmp-q.json` (9 occurrences in English response option text)

## Testing

✅ `codespell` passes with zero errors after all fixes

---

🤖 Generated with [Claude Code](https://claude.com/claude-code) and love to typos free code
