### PR TITLE
Survey workflow project-path hardening and shim runtime compatibility

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -1,6 +1,6 @@
 # PRISM Studio - Roadmap
 
-Last updated: 2026-05-11
+Last updated: 2026-05-12
 
 ## Current Mission
 
@@ -34,6 +34,25 @@ What is already completed:
 - Unified command adapter route added and wired across prepare/preview/convert paths.
 - Focused regression coverage expanded for workflow wiring, preview contracts, stale wrappers, and command dispatch aliases.
 - Full-suite coverage remains above fail-under threshold (80%).
+- Survey workflow request payloads now propagate explicit project_path across prepare/preview/convert paths.
+- Backend survey preview and convert-validate paths now prefer explicit project_path and reject stale explicit paths before conversion stages.
+- New workflow-endpoint contract coverage added for stale explicit project rejection and explicit project precedence under /api/survey-workflow-command.
+- Added backend src compatibility bridge for `src._compat` so mirrored app converter shims load reliably in repo-root runtime as well as app runtime.
+- Added repo-runtime shim regression coverage in tests/test_compat_loader.py to prevent future adapter import drift.
+
+Latest checkpoint (2026-05-12):
+- Completed implementation slice: explicit project-path hardening for survey workflow frontend and backend.
+- Completed implementation slice: repo/runtime compatibility hardening for converter shims via backend `src._compat` bridge.
+- Focused suites green:
+  - ./rtk test tests/test_converter_workflow_wiring.py tests/test_converter_project_save_contracts.py tests/test_compat_loader.py
+  - ./rtk test tests/test_web_blueprints_conversion.py -k "test_api_survey_convert_blocks_until_templates_completed or test_api_survey_convert_forwards_template_version_overrides or test_api_survey_convert_registers_detected_sessions_for_all"
+
+Lessons learned:
+- For workflow refactors, project context must be treated as request-scoped data; relying on session-only context is fragile for multi-tab and delayed-switch flows.
+- Contract tests should exercise the unified adapter endpoint (/api/survey-workflow-command), not only legacy alias endpoints, to catch integration drift early.
+- Run at least one broader targeted blueprint subset after endpoint refactors; this quickly surfaces NameError/scope regressions that focused wiring tests can miss.
+- Mirrored shims should be tested in both app-root and repo-root import contexts; one-sided runtime tests can miss `src._compat` resolution failures.
+- Keep RTK-first discipline for repo validation (`./rtk test ...`), so CI/local command surfaces stay aligned before PR creation.
 
 #### Stacked PR Playbook (execution target)
 

--- a/app/src/web/blueprints/conversion_survey_handlers.py
+++ b/app/src/web/blueprints/conversion_survey_handlers.py
@@ -193,6 +193,41 @@ def _format_workflow_preparation_stale_response(
     )
 
 
+def _requested_project_path() -> str | None:
+    raw_value = (
+        request.form.get("project_path")
+        or request.args.get("project_path")
+        or ""
+    )
+    normalized = str(raw_value).strip()
+    return normalized or None
+
+
+def _resolve_requested_project_root(*, require_project: bool) -> Path | None:
+    missing_message = "No project selected. Load a project before converting survey data."
+    missing_path_message = (
+        "The selected project path no longer exists. Reopen the project and retry survey conversion."
+    )
+
+    requested_project_path = _requested_project_path()
+    if requested_project_path:
+        return require_existing_project_root(
+            requested_project_path,
+            missing_message=missing_message,
+            missing_path_message=missing_path_message,
+        )
+
+    session_project_path = session.get("current_project_path")
+    if require_project:
+        return require_existing_project_root(
+            session_project_path,
+            missing_message=missing_message,
+            missing_path_message=missing_path_message,
+        )
+
+    return resolve_existing_project_root(session_project_path)
+
+
 def _iter_session_registration_values(
     *,
     session_override: str | None,
@@ -1495,6 +1530,15 @@ def api_survey_detect_version_context():
     if suffix not in _SUPPORTED_SURVEY_INPUT_SUFFIXES:
         return jsonify({"error": _SUPPORTED_SURVEY_INPUT_MESSAGE}), 400
 
+    try:
+        requested_project_root = _resolve_requested_project_root(require_project=False)
+    except (ValueError, FileNotFoundError) as error:
+        return jsonify({"error": str(error)}), 400
+
+    requested_project_path = (
+        str(requested_project_root) if requested_project_root else None
+    )
+
     raw_survey_filter = (request.form.get("survey") or "").strip() or None
     try:
         selected_tasks = parse_selected_survey_tasks(
@@ -1541,7 +1585,7 @@ def api_survey_detect_version_context():
     except ValueError as error:
         return jsonify({"error": str(error)}), 400
 
-    project_path = session.get("current_project_path")
+    project_path = requested_project_path
     effective_template_version_overrides = _get_effective_template_version_overrides(
         project_path=project_path,
         template_version_overrides=template_version_overrides,
@@ -1563,7 +1607,7 @@ def api_survey_detect_version_context():
             uploaded_file=uploaded_file,
             filename=filename,
             library_dir=library_path,
-            project_path=str(project_path) if project_path else None,
+            project_path=project_path,
             survey=survey_filter,
             id_column=id_column,
             session_column=session_column,
@@ -1646,6 +1690,15 @@ def api_survey_convert():
     if suffix not in _SUPPORTED_SURVEY_INPUT_SUFFIXES:
         return jsonify({"error": _SUPPORTED_SURVEY_INPUT_MESSAGE}), 400
 
+    try:
+        requested_project_root = _resolve_requested_project_root(require_project=False)
+    except (ValueError, FileNotFoundError) as error:
+        return jsonify({"error": str(error)}), 400
+
+    requested_project_path = (
+        str(requested_project_root) if requested_project_root else None
+    )
+
     alias_filename = None
     if alias_upload and getattr(alias_upload, "filename", ""):
         alias_filename = secure_filename(alias_upload.filename)
@@ -1674,7 +1727,9 @@ def api_survey_convert():
     try:
         effective_survey_dir = _survey_workflow_stage_service.resolve_effective_survey_dir(
             library_path=library_path,
-            fallback_project_path=session.get("current_project_path"),
+            fallback_project_path=(
+                requested_project_path or session.get("current_project_path")
+            ),
             resolve_official_survey_dir=_resolve_official_survey_dir,
         )
     except FileNotFoundError as error:
@@ -1694,7 +1749,7 @@ def api_survey_convert():
         )
     except ValueError as error:
         return jsonify({"error": str(error)}), 400
-    current_project_path = session.get("current_project_path")
+    current_project_path = requested_project_path or session.get("current_project_path")
     effective_template_version_overrides = _get_effective_template_version_overrides(
         project_path=current_project_path,
         template_version_overrides=template_version_overrides,
@@ -1729,14 +1784,13 @@ def api_survey_convert():
     project_root = None
     current_project_path = None
     if save_to_project:
-        try:
-            project_root = require_existing_project_root(
-                session.get("current_project_path"),
-                missing_message="No project selected. Load a project before converting survey data.",
-                missing_path_message="The selected project path no longer exists. Reopen the project and retry survey conversion.",
-            )
-        except (ValueError, FileNotFoundError) as error:
-            return jsonify({"error": str(error)}), 400
+        if requested_project_root is not None:
+            project_root = requested_project_root
+        else:
+            try:
+                project_root = _resolve_requested_project_root(require_project=True)
+            except (ValueError, FileNotFoundError) as error:
+                return jsonify({"error": str(error)}), 400
         current_project_path = str(project_root)
     duplicate_handling = parsed_stage_fields.duplicate_handling
     try:
@@ -2135,6 +2189,21 @@ def api_survey_convert_validate():
         )
 
     try:
+        project_root = _resolve_requested_project_root(require_project=True)
+    except (ValueError, FileNotFoundError) as error:
+        return (
+            jsonify(
+                {
+                    "error": str(error),
+                    "log": log_messages,
+                }
+            ),
+            400,
+        )
+
+    current_project_path = str(project_root) if project_root else None
+
+    try:
         library_path = _resolve_effective_library_path()
     except FileNotFoundError as e:
         return jsonify({"error": str(e), "log": log_messages}), 400
@@ -2142,7 +2211,7 @@ def api_survey_convert_validate():
     try:
         effective_survey_dir = _survey_workflow_stage_service.resolve_effective_survey_dir(
             library_path=library_path,
-            fallback_project_path=session.get("current_project_path"),
+            fallback_project_path=current_project_path,
             resolve_official_survey_dir=_resolve_official_survey_dir,
         )
     except FileNotFoundError as error:
@@ -2162,7 +2231,6 @@ def api_survey_convert_validate():
         )
     except ValueError as error:
         return jsonify({"error": str(error), "log": log_messages}), 400
-    current_project_path = session.get("current_project_path")
     effective_template_version_overrides = _get_effective_template_version_overrides(
         project_path=current_project_path,
         template_version_overrides=template_version_overrides,
@@ -2215,23 +2283,16 @@ def api_survey_convert_validate():
             400,
         )
 
-    try:
-        project_root = require_existing_project_root(
-            session.get("current_project_path"),
-            missing_message="No project selected. Load a project before converting survey data.",
-            missing_path_message="The selected project path no longer exists. Reopen the project and retry survey conversion.",
-        )
-    except (ValueError, FileNotFoundError) as error:
+    if current_project_path is None:
         return (
             jsonify(
                 {
-                    "error": str(error),
+                    "error": "No project selected. Load a project before converting survey data.",
                     "log": log_messages,
                 }
             ),
             400,
         )
-    current_project_path = str(project_root)
     try:
         separator_option = normalize_separator_option(request.form.get("separator"))
     except ValueError as error:

--- a/app/src/web/blueprints/conversion_survey_preview_handlers.py
+++ b/app/src/web/blueprints/conversion_survey_preview_handlers.py
@@ -30,6 +30,8 @@ from .conversion_utils import (
     parse_selected_survey_tasks,
     parse_task_value_offsets,
     parse_template_version_overrides,
+    require_existing_project_root,
+    resolve_existing_project_root,
     resolve_validation_library_path,
 )
 
@@ -237,6 +239,37 @@ def _format_workflow_preparation_stale_response(
     )
 
 
+def _resolve_requested_project_root(*, require_project: bool) -> Path | None:
+    requested_project_path = (
+        (request.form.get("project_path") or request.args.get("project_path") or "")
+        .strip()
+        or None
+    )
+    missing_message = (
+        "No project selected. Load a project before previewing survey data."
+    )
+    missing_path_message = (
+        "The selected project path no longer exists. Reopen the project and retry survey preview."
+    )
+
+    if requested_project_path:
+        return require_existing_project_root(
+            requested_project_path,
+            missing_message=missing_message,
+            missing_path_message=missing_path_message,
+        )
+
+    session_project_path = session.get("current_project_path")
+    if require_project:
+        return require_existing_project_root(
+            session_project_path,
+            missing_message=missing_message,
+            missing_path_message=missing_path_message,
+        )
+
+    return resolve_existing_project_root(session_project_path)
+
+
 def handle_api_survey_languages(participant_json_candidates):
     """List available languages for the selected survey template library folder."""
     library_path = (request.args.get("library_path") or "").strip()
@@ -427,6 +460,13 @@ def handle_api_survey_convert_preview(
             )
 
     try:
+        project_path = _resolve_requested_project_root(require_project=False)
+    except (ValueError, FileNotFoundError) as error:
+        return jsonify({"error": str(error)}), 400
+
+    project_path_text = str(project_path) if project_path else None
+
+    try:
         library_path = resolve_effective_library_path()
     except FileNotFoundError as error:
         return jsonify({"error": str(error)}), 400
@@ -439,7 +479,7 @@ def handle_api_survey_convert_preview(
     effective_survey_dir = survey_dir
 
     print(f"[PRISM DEBUG] DRY-RUN Preview using library: {effective_survey_dir}")
-    print(f"[PRISM DEBUG] Session project path: {session.get('current_project_path')}")
+    print(f"[PRISM DEBUG] Session project path: {project_path_text}")
     print(
         f"[PRISM DEBUG] Available templates: {list(effective_survey_dir.glob('survey-*.json'))}"
     )
@@ -451,7 +491,7 @@ def handle_api_survey_convert_preview(
         from .conversion_survey_handlers import _resolve_official_survey_dir
 
         official_fallback = _resolve_official_survey_dir(
-            session.get("current_project_path")
+            project_path_text
         )
         if official_fallback:
             effective_survey_dir = official_fallback
@@ -477,9 +517,8 @@ def handle_api_survey_convert_preview(
         )
     except ValueError as error:
         return jsonify({"error": str(error)}), 400
-    current_project_path = session.get("current_project_path")
     effective_template_version_overrides = _get_effective_template_version_overrides(
-        project_path=current_project_path,
+        project_path=project_path_text,
         template_version_overrides=template_version_overrides,
     )
     id_column = (request.form.get("id_column") or "").strip() or None
@@ -548,12 +587,7 @@ def handle_api_survey_convert_preview(
             id_map_path = tmp_dir_path / id_map_filename
             id_map_upload.save(str(id_map_path))
 
-        project_path = session.get("current_project_path")
         if project_path:
-            project_path = Path(project_path)
-            if project_path.is_file():
-                project_path = project_path.parent
-
             mapping_candidates = participants_mapping_candidates(project_path)
 
             for mapping_file in mapping_candidates:

--- a/app/static/js/modules/converter/survey-convert.js
+++ b/app/static/js/modules/converter/survey-convert.js
@@ -1395,6 +1395,10 @@ export function initSurveyConvert(elements) {
         includeIdMap = true,
     } = {}) {
         const formData = new FormData();
+        const currentProjectPath = resolveCurrentProjectPath();
+        if (currentProjectPath) {
+            formData.append('project_path', currentProjectPath);
+        }
         const inputSelection = appendSurveyInputToFormData(formData);
         const filename = inputSelection.filename || getSelectedSurveyFilename();
         if (!inputSelection.filename) {
@@ -2406,6 +2410,7 @@ export function initSurveyConvert(elements) {
         getSurveyPreviewContextKey,
         getSelectedSurveyFilename,
         getSelectedSurveyFile,
+        resolveCurrentProjectPath,
         isAdvancedOptionsEnabled,
         refreshSurveyColumnsBeforeRun,
         setActiveSurveyRun,
@@ -2486,6 +2491,7 @@ export function initSurveyConvert(elements) {
         getSelectedSurveyFilename,
         getSelectedSurveyFile,
         getSurveySessionValue,
+        resolveCurrentProjectPath,
         isAdvancedOptionsEnabled,
         refreshSurveyColumnsBeforeRun,
         setActiveSurveyRun,

--- a/app/static/js/modules/converter/survey-workflow-convert.js
+++ b/app/static/js/modules/converter/survey-workflow-convert.js
@@ -34,6 +34,7 @@ export function createSurveyWorkflowConvertController({
     focusTaskValueOffsetEditor,
     getSelectedSurveyFilename,
     getSelectedSurveyFile,
+    resolveCurrentProjectPath,
     getSurveySessionValue,
     isAdvancedOptionsEnabled,
     refreshSurveyColumnsBeforeRun,
@@ -194,6 +195,10 @@ export function createSurveyWorkflowConvertController({
         allowNearItemMatch = selectedNearMatchTasks.length > 0;
 
         const formData = new FormData();
+        const currentProjectPath = resolveCurrentProjectPath();
+        if (currentProjectPath) {
+            formData.append('project_path', currentProjectPath);
+        }
         appendSurveyInputToFormData(formData);
         if (file) {
             console.log(`[CLIENT DEBUG] Excel file: ${file.name}, size: ${file.size}`);

--- a/app/static/js/modules/converter/survey-workflow-preview.js
+++ b/app/static/js/modules/converter/survey-workflow-preview.js
@@ -30,6 +30,7 @@ export function createSurveyWorkflowPreviewController({
     getSurveyPreviewContextKey,
     getSelectedSurveyFilename,
     getSelectedSurveyFile,
+    resolveCurrentProjectPath,
     isAdvancedOptionsEnabled,
     refreshSurveyColumnsBeforeRun,
     setActiveSurveyRun,
@@ -164,6 +165,10 @@ export function createSurveyWorkflowPreviewController({
         allowNearItemMatch = selectedNearMatchTasks.length > 0;
 
         const formData = new FormData();
+        const currentProjectPath = resolveCurrentProjectPath();
+        if (currentProjectPath) {
+            formData.append('project_path', currentProjectPath);
+        }
         appendSurveyInputToFormData(formData);
 
         if (idMap) {

--- a/src/_compat.py
+++ b/src/_compat.py
@@ -1,0 +1,46 @@
+"""Compatibility bridge for mirrored app converter shims.
+
+Some mirrored modules under app/src import `src._compat` to obtain
+`load_canonical_module`. In repo-root runtimes, top-level `src` is the backend
+package, so this bridge forwards to app/src/_compat.py.
+"""
+
+from __future__ import annotations
+
+from importlib.util import module_from_spec, spec_from_file_location
+from pathlib import Path
+import sys
+from types import ModuleType
+from typing import Callable
+
+_APP_COMPAT_ALIAS = "prism_app_src_compat_bridge"
+
+
+def _load_app_compat_module() -> ModuleType:
+    existing = sys.modules.get(_APP_COMPAT_ALIAS)
+    if isinstance(existing, ModuleType):
+        return existing
+
+    repo_root = Path(__file__).resolve().parents[1]
+    app_compat_path = repo_root / "app" / "src" / "_compat.py"
+    if not app_compat_path.exists():
+        raise ImportError(f"Missing compatibility helper: {app_compat_path}")
+
+    spec = spec_from_file_location(_APP_COMPAT_ALIAS, str(app_compat_path))
+    if spec is None or spec.loader is None:
+        raise ImportError(f"Unable to load compatibility helper: {app_compat_path}")
+
+    module = module_from_spec(spec)
+    sys.modules[_APP_COMPAT_ALIAS] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+_app_compat = _load_app_compat_module()
+_load_canonical = getattr(_app_compat, "load_canonical_module", None)
+if not callable(_load_canonical):
+    raise ImportError("app/src/_compat.py does not export load_canonical_module")
+
+load_canonical_module: Callable[..., ModuleType] = _load_canonical
+
+__all__ = ["load_canonical_module"]

--- a/tests/test_compat_loader.py
+++ b/tests/test_compat_loader.py
@@ -231,6 +231,21 @@ def test_biometrics_converter_shim_loads_in_app_runtime(monkeypatch) -> None:
     assert callable(getattr(loaded, "convert_biometrics_table_to_prism_dataset", None))
 
 
+def test_biometrics_converter_shim_loads_in_repo_runtime(monkeypatch) -> None:
+    repo_root = Path(__file__).resolve().parents[1]
+    biometrics_file = repo_root / "app" / "src" / "converters" / "biometrics.py"
+
+    monkeypatch.syspath_prepend(str(repo_root))
+
+    loaded = _load_module_from_path(
+        "biometrics_shim_repo_runtime_test",
+        biometrics_file,
+    )
+
+    assert callable(getattr(loaded, "detect_biometrics_in_table", None))
+    assert callable(getattr(loaded, "convert_biometrics_table_to_prism_dataset", None))
+
+
 def test_file_reader_shim_loads_in_app_runtime(monkeypatch) -> None:
     app_root = Path(__file__).resolve().parents[1] / "app"
     file_reader_file = app_root / "src" / "converters" / "file_reader.py"
@@ -244,6 +259,38 @@ def test_file_reader_shim_loads_in_app_runtime(monkeypatch) -> None:
 
     assert callable(getattr(loaded, "read_tabular_file", None))
     assert getattr(loaded, "ReadResult", None) is not None
+
+
+def test_file_reader_shim_loads_in_repo_runtime(monkeypatch) -> None:
+    repo_root = Path(__file__).resolve().parents[1]
+    file_reader_file = repo_root / "app" / "src" / "converters" / "file_reader.py"
+
+    monkeypatch.syspath_prepend(str(repo_root))
+
+    loaded = _load_module_from_path(
+        "file_reader_shim_repo_runtime_test",
+        file_reader_file,
+    )
+
+    assert callable(getattr(loaded, "read_tabular_file", None))
+    assert getattr(loaded, "ReadResult", None) is not None
+
+
+def test_wide_to_long_shim_loads_in_repo_runtime(monkeypatch) -> None:
+    repo_root = Path(__file__).resolve().parents[1]
+    wide_to_long_file = (
+        repo_root / "app" / "src" / "converters" / "wide_to_long.py"
+    )
+
+    monkeypatch.syspath_prepend(str(repo_root))
+
+    loaded = _load_module_from_path(
+        "wide_to_long_shim_repo_runtime_test",
+        wide_to_long_file,
+    )
+
+    assert callable(getattr(loaded, "detect_wide_session_prefixes", None))
+    assert callable(getattr(loaded, "inspect_wide_to_long_columns", None))
 
 
 def test_participants_converter_imports_in_app_runtime(monkeypatch) -> None:

--- a/tests/test_converter_project_save_contracts.py
+++ b/tests/test_converter_project_save_contracts.py
@@ -38,6 +38,11 @@ def _build_app_and_handlers():
         methods=["POST"],
     )
     app.add_url_rule(
+        "/api/survey-workflow-command",
+        view_func=survey.api_survey_workflow_command,
+        methods=["POST"],
+    )
+    app.add_url_rule(
         "/api/batch-convert-start",
         view_func=physio.api_batch_convert_start,
         methods=["POST"],
@@ -320,6 +325,166 @@ def test_survey_convert_validate_returns_participant_registry_warning(
     assert payload["conversion_summary"]["participant_registry_warning"][
         "action"
     ]["target"] == "participants"
+
+
+def test_survey_workflow_preview_rejects_stale_explicit_project_path(
+    tmp_path, monkeypatch
+):
+    app, _biometrics, survey, _physio, _environment = _build_app_and_handlers()
+    current_project = tmp_path / "project-current"
+    current_project.mkdir(parents=True, exist_ok=True)
+
+    stale_project = tmp_path / "missing-project"
+
+    library_root = tmp_path / "library"
+    survey_dir = library_root / "survey"
+    survey_dir.mkdir(parents=True, exist_ok=True)
+    (survey_dir / "survey-demo.json").write_text("{}", encoding="utf-8")
+
+    monkeypatch.setattr(survey, "_resolve_effective_library_path", lambda: library_root)
+
+    def fake_run_survey_with_official_fallback(_converter, **_kwargs):
+        return SimpleNamespace(
+            dry_run_preview={},
+            tasks_included=["demo"],
+            unknown_columns=[],
+            missing_items_by_task={},
+            id_column="participant_id",
+            session_column=None,
+            run_column=None,
+            detected_sessions=[],
+            conversion_warnings=[],
+            task_runs={},
+            template_matches=None,
+            near_match_candidates=[],
+            near_match_applied=False,
+            applied_value_offsets={},
+            value_offset_application_counts={},
+            participant_registry_warning=None,
+            tool_columns=[],
+        )
+
+    monkeypatch.setattr(
+        survey,
+        "_run_survey_with_official_fallback",
+        fake_run_survey_with_official_fallback,
+    )
+
+    with app.test_client() as client:
+        with client.session_transaction() as sess:
+            sess["current_project_path"] = str(current_project)
+
+        response = client.post(
+            "/api/survey-workflow-command",
+            data={
+                "workflow_command": "preview",
+                "project_path": str(stale_project),
+                "validate": "false",
+                "id_column": "participant_id",
+                "excel": (
+                    io.BytesIO(b"participant_id,score\nsub-01,1\n"),
+                    "survey.csv",
+                ),
+            },
+            content_type="multipart/form-data",
+        )
+
+    assert response.status_code == 400
+    payload = response.get_json()
+    assert "no longer exists" in payload["error"].lower()
+
+
+def test_survey_workflow_convert_prefers_explicit_project_path(
+    tmp_path, monkeypatch
+):
+    app, _biometrics, survey, _physio, _environment = _build_app_and_handlers()
+    stale_session_project = tmp_path / "missing-project"
+    explicit_project = tmp_path / "project-explicit"
+    explicit_project.mkdir(parents=True, exist_ok=True)
+
+    library_root = tmp_path / "library"
+    survey_dir = library_root / "survey"
+    survey_dir.mkdir(parents=True, exist_ok=True)
+    (survey_dir / "survey-demo.json").write_text("{}", encoding="utf-8")
+
+    monkeypatch.setattr(survey, "_resolve_effective_library_path", lambda: library_root)
+    monkeypatch.setattr(
+        survey,
+        "_validate_project_templates_for_tasks",
+        lambda **_kwargs: [],
+    )
+
+    def fake_run_survey_with_official_fallback(_converter, **kwargs):
+        output_root = Path(kwargs["output_root"])
+        if not kwargs.get("dry_run"):
+            output_file = (
+                output_root
+                / "sub-01"
+                / "ses-01"
+                / "survey"
+                / "sub-01_ses-01_task-demo_survey.tsv"
+            )
+            output_file.parent.mkdir(parents=True, exist_ok=True)
+            output_file.write_text(
+                "participant_id\tscore\nsub-01\t1\n", encoding="utf-8"
+            )
+
+        return SimpleNamespace(
+            tasks_included=["demo"],
+            unknown_columns=[],
+            task_runs={},
+            tool_columns=[],
+            template_matches=None,
+            near_match_candidates=[],
+            near_match_applied=False,
+            conversion_warnings=[],
+            participant_registry_warning=None,
+            dry_run_preview={},
+            missing_items_by_task={},
+            id_column="participant_id",
+            session_column=None,
+            run_column=None,
+            detected_sessions=["01"],
+            applied_value_offsets={},
+            value_offset_application_counts={},
+        )
+
+    monkeypatch.setattr(
+        survey,
+        "_run_survey_with_official_fallback",
+        fake_run_survey_with_official_fallback,
+    )
+
+    with app.test_client() as client:
+        with client.session_transaction() as sess:
+            sess["current_project_path"] = str(stale_session_project)
+
+        response = client.post(
+            "/api/survey-workflow-command",
+            data={
+                "workflow_command": "convert",
+                "project_path": str(explicit_project),
+                "id_column": "participant_id",
+                "session": "01",
+                "validate": "false",
+                "excel": (
+                    io.BytesIO(b"participant_id,score\nsub-01,1\n"),
+                    "survey.csv",
+                ),
+            },
+            content_type="multipart/form-data",
+        )
+
+    assert response.status_code == 200
+    payload = response.get_json()
+    assert payload["project_saved"] is True
+    assert (
+        explicit_project
+        / "sub-01"
+        / "ses-01"
+        / "survey"
+        / "sub-01_ses-01_task-demo_survey.tsv"
+    ).exists()
 
 
 def test_batch_convert_start_rejects_stale_project_path(tmp_path):

--- a/tests/test_converter_workflow_wiring.py
+++ b/tests/test_converter_workflow_wiring.py
@@ -444,6 +444,12 @@ class TestConverterWorkflowWiring(unittest.TestCase):
         workflow_prepare_content = SURVEY_WORKFLOW_PREPARE_MODULE.read_text(
             encoding="utf-8"
         )
+        workflow_preview_content = SURVEY_WORKFLOW_PREVIEW_MODULE.read_text(
+            encoding="utf-8"
+        )
+        workflow_convert_content = SURVEY_WORKFLOW_CONVERT_MODULE.read_text(
+            encoding="utf-8"
+        )
         survey_sourcedata_content = (
             SURVEY_SOURCEDATA_QUICK_SELECT_MODULE.read_text(encoding="utf-8")
         )
@@ -518,6 +524,24 @@ class TestConverterWorkflowWiring(unittest.TestCase):
         self.assertIn(
             "data = await parseJsonResponse(response, 'Survey preparation');",
             workflow_prepare_content,
+        )
+        self.assertIn("const currentProjectPath = resolveCurrentProjectPath();", content)
+        self.assertIn("formData.append('project_path', currentProjectPath);", content)
+        self.assertIn(
+            "const currentProjectPath = resolveCurrentProjectPath();",
+            workflow_preview_content,
+        )
+        self.assertIn(
+            "formData.append('project_path', currentProjectPath);",
+            workflow_preview_content,
+        )
+        self.assertIn(
+            "const currentProjectPath = resolveCurrentProjectPath();",
+            workflow_convert_content,
+        )
+        self.assertIn(
+            "formData.append('project_path', currentProjectPath);",
+            workflow_convert_content,
         )
 
     def test_survey_converter_project_change_clears_project_bound_selection_state(self):


### PR DESCRIPTION
## Summary
- enforce explicit project_path propagation and precedence across survey workflow prepare, preview, and convert paths
- harden backend workflow handlers to validate explicit project paths and reject stale explicit selections
- add compatibility bridge for src._compat to keep mirrored converter shims stable in repo-root runtime and app runtime
- expand focused wiring and contract coverage for unified workflow command behavior and shim loading

## Validation (RTK-first)
- ./rtk test tests/test_converter_workflow_wiring.py tests/test_converter_project_save_contracts.py tests/test_compat_loader.py
- ./rtk test tests/test_web_blueprints_conversion.py -k "test_api_survey_convert_blocks_until_templates_completed or test_api_survey_convert_forwards_template_version_overrides or test_api_survey_convert_registers_detected_sessions_for_all"
- ./rtk test tests/test_converter_project_save_contracts.py tests/test_web_blueprints_conversion.py -k "survey_workflow_command or survey_convert_blocks_until_templates_completed or survey_convert_forwards_template_version_overrides or survey_convert_registers_detected_sessions_for_all"

## Commits
- converter: enforce explicit project-path workflow contracts
- compat: bridge src._compat and add repo-runtime shim tests
- docs: update roadmap checkpoint for workflow hardening