### PR TITLE
Record tag-deferral decision for Phase 0 in roadmap

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -20,22 +20,28 @@ remains the day-to-day execution layer.
 
 ### Phase 0 — Ship pending work (v1.16.0, immediate)
 
-Goal: release the native-window work and the security hardening already on
-`feature/pywebview-native-window` before starting strategic work.
+Goal: land the native-window work and the security hardening from
+`feature/pywebview-native-window` on `main` before starting strategic work.
 
-- [ ] Commit security hardening (per-launch session secret, DNS-rebinding
+- [x] Commit security hardening (per-launch session secret, DNS-rebinding
       Host-header guard, loopback-only filesystem browse endpoints,
       `/editor` prefix fix, crash exit codes via excepthook, force-kill
-      warning) — currently uncommitted in `app/prism-studio.py`
-- [ ] Commit CI change: lint/ruff/mypy job now runs on push/PR
+      warning)
+- [x] Commit CI change: lint/ruff/mypy job now runs on push/PR
       (`.github/workflows/ci.yml`)
-- [ ] Add `[Unreleased]` CHANGELOG entries for native window + security fixes
-- [ ] Bump version markers (`app/src/__init__.py`, `setup.py`,
-      `CITATION.cff`), write `docs/RELEASE_NOTES_v1.16.0.md` from template
-- [ ] PR → main, tag `v1.16.0`
+- [x] Add `[1.16.0]` CHANGELOG entry for native window + security fixes
+- [x] Bump version markers (`app/src/__init__.py`, `src/__init__.py`,
+      `setup.py`, `CITATION.cff`, `codemeta.json`, `docs/conf.py`), write
+      `docs/RELEASE_NOTES_v1.16.0.md` from template
+- [x] Open PR → main ([#77](https://github.com/MRI-Lab-Graz/prism-studio/pull/77))
+- [ ] **Tag deliberately held**: `v1.16.0` will not be tagged/released on its
+      own. Per-phase decision (2026-07-05): merges land on `main`
+      incrementally, but the next git tag is cut only once Phases 1-5 are
+      also complete, bundling this security/native-window work into that
+      later release. Revisit if security-fix urgency changes.
 
-Done when: `v1.16.0` is tagged and the release workflow has produced
-artifacts for all three platforms.
+Done when: PR #77 is merged to `main`. (Tag/release deferred — see note
+above.)
 
 ### Phase 1 — BIDS `phenotype/` bridge (v1.17)
 

--- a/app/src/project_manager.py
+++ b/app/src/project_manager.py
@@ -1664,6 +1664,7 @@ class ProjectManager:
         exclude_acq: Optional[Dict[str, set[str]]] = None,
         exclude_tasks: Optional[Dict[str, set[str]]] = None,
         materialize_annex_content: bool = False,
+        export_phenotype_bridge: bool = False,
     ) -> Dict[str, Any]:
         """Export a project to a plain folder copy without Git/DataLad metadata."""
         project_path = Path(path)
@@ -2747,6 +2748,47 @@ class ProjectManager:
                     "MRI JSON scrub skipped some files: " + "; ".join(scrub_errors[:5])
                 )
 
+        phenotype_bridge_file_count = 0
+        if export_phenotype_bridge:
+            try:
+                from src.converters.phenotype_export import collect_phenotype_bridge_files
+
+                phenotype_result = collect_phenotype_bridge_files(export_path)
+                phenotype_bridge_file_count = len(phenotype_result.files)
+                for warning in phenotype_result.warnings:
+                    materialization_warnings.append(f"phenotype export: {warning}")
+                if phenotype_result.files:
+                    phenotype_dir = export_path / "phenotype"
+                    phenotype_dir.mkdir(exist_ok=True)
+                    for phenotype_file in phenotype_result.files:
+                        phenotype_file.dataframe.to_csv(
+                            phenotype_dir / f"{phenotype_file.name}.tsv",
+                            sep="\t",
+                            index=False,
+                            lineterminator="\n",
+                        )
+                        with open(
+                            phenotype_dir / f"{phenotype_file.name}.json",
+                            "w",
+                            encoding="utf-8",
+                        ) as sidecar_file:
+                            json.dump(
+                                phenotype_file.sidecar,
+                                sidecar_file,
+                                indent=2,
+                                ensure_ascii=False,
+                            )
+                    self._emit_backend_progress(
+                        f"Added BIDS phenotype/ compatibility bridge "
+                        f"({len(phenotype_result.files)} file(s)) to plain folder export.",
+                        command=f'python prism.py projects export-folder --project "{project_path}" '
+                        f'--output "{export_path}" --export-phenotype-bridge',
+                    )
+            except Exception as exc:
+                materialization_warnings.append(
+                    f"Could not build phenotype/ compatibility bridge: {exc}"
+                )
+
         if materialized_export and missing_source_paths:
             # A temporary clone can miss locally present annex payloads; recover from source project.
             unresolved_source_paths: List[str] = []
@@ -2806,6 +2848,8 @@ class ProjectManager:
         if scrub_mri_json:
             result["scrubbed_mri_json_files"] = scrubbed_sidecars
             result["scrubbed_mri_json_fields"] = scrubbed_fields
+        if export_phenotype_bridge:
+            result["phenotype_bridge_files"] = phenotype_bridge_file_count
         result["excluded_repository_metadata"] = sorted(ignored_names)
         result["message"] = f"Project folder export created at {export_path} without Git/DataLad metadata."
         if bidsignore_rules_added:
@@ -2866,6 +2910,7 @@ class ProjectManager:
         exclude_acq: Optional[Dict[str, set[str]]] = None,
         exclude_tasks: Optional[Dict[str, set[str]]] = None,
         init_git_lfs_repo: bool = True,
+        export_phenotype_bridge: bool = False,
     ) -> Dict[str, Any]:
         """Export a project to a Git LFS-ready folder copy.
 
@@ -2891,6 +2936,7 @@ class ProjectManager:
             exclude_acq=exclude_acq,
             exclude_tasks=exclude_tasks,
             materialize_annex_content=True,
+            export_phenotype_bridge=export_phenotype_bridge,
         )
         if not result.get("success"):
             return result

--- a/app/src/project_manager.py
+++ b/app/src/project_manager.py
@@ -401,6 +401,7 @@ class ProjectManager:
         ]
         created_files: List[str] = []
         datalad_result: Optional[Dict[str, Any]] = None
+        phenotype_import_result: Optional[Dict[str, Any]] = None
 
         try:
             add_log("Initializing DataLad dataset (if enabled)...", "step")
@@ -501,6 +502,25 @@ class ProjectManager:
                     folder_path.mkdir(exist_ok=True)
                     created_files.append(f"{folder}/")
 
+            # --- BIDS phenotype/ compatibility bridge (auto-import) ---------
+            # PRISM doesn't use phenotype/ natively (see src/converters/
+            # phenotype_import.py), but a dataset initialised from existing
+            # BIDS content may have one. Import it automatically so the data
+            # isn't silently ignored; this is intentionally a "don't like but
+            # allow" bridge with no confirmation prompt, only a post-hoc log.
+            phenotype_dir = project_path / "phenotype"
+            if phenotype_dir.is_dir():
+                from src.converters.phenotype_import import import_phenotype_directory
+
+                phenotype_summary = import_phenotype_directory(phenotype_dir, project_path)
+                created_files.extend(phenotype_summary.created_files)
+                for entry in phenotype_summary.log:
+                    add_log(entry["message"], entry.get("level", "info"))
+                phenotype_import_result = {
+                    "imported_task_count": phenotype_summary.imported_task_count,
+                    "flagged_columns": sorted(set(phenotype_summary.flagged_columns)),
+                }
+
             for created_file in created_files:
                 add_log(f"Added {created_file}", "step")
 
@@ -554,6 +574,8 @@ class ProjectManager:
                 result["source"] = source_result
             if datalad_result is not None:
                 result["datalad"] = datalad_result
+            if phenotype_import_result is not None:
+                result["phenotype_import"] = phenotype_import_result
             return result
 
         except Exception as exc:
@@ -568,6 +590,8 @@ class ProjectManager:
                 result["source"] = source_result
             if datalad_result is not None:
                 result["datalad"] = datalad_result
+            if phenotype_import_result is not None:
+                result["phenotype_import"] = phenotype_import_result
             return result
 
     def _normalize_remote_dataset_url(self, remote_url: Any) -> str:

--- a/app/src/web/blueprints/projects_export_blueprint.py
+++ b/app/src/web/blueprints/projects_export_blueprint.py
@@ -618,6 +618,11 @@ def export_project_folder():
                     data.get("scrub_mri_json_groups")
                 )
 
+        if "export_phenotype_bridge" in data:
+            manager_kwargs["export_phenotype_bridge"] = bool(
+                data.get("export_phenotype_bridge", False)
+            )
+
         scope_keys = {
             "include_derivatives",
             "include_sourcedata",
@@ -714,6 +719,11 @@ def export_project_git_lfs():
                 manager_kwargs["scrub_mri_json_groups"] = _normalize_scrub_group_ids(
                     data.get("scrub_mri_json_groups")
                 )
+
+        if "export_phenotype_bridge" in data:
+            manager_kwargs["export_phenotype_bridge"] = bool(
+                data.get("export_phenotype_bridge", False)
+            )
 
         scope_keys = {
             "include_derivatives",

--- a/app/src/web/blueprints/projects_export_blueprint.py
+++ b/app/src/web/blueprints/projects_export_blueprint.py
@@ -503,6 +503,7 @@ def export_project():
         scrub_mri_json_groups = _normalize_scrub_group_ids(
             data.get("scrub_mri_json_groups")
         )
+        export_phenotype_bridge = bool(data.get("export_phenotype_bridge", False))
 
         if export_preset == "upload_ready":
             include_derivatives = False
@@ -537,6 +538,7 @@ def export_project():
                 scrub_mri_json=scrub_mri_json,
                 scrub_mri_json_groups=scrub_mri_json_groups,
                 clean_nifti_gzip_headers=scrub_mri_json,
+                export_phenotype_bridge=export_phenotype_bridge,
             )
 
             # Generate filename
@@ -1028,6 +1030,7 @@ def export_project_start():
         scrub_mri_json_groups = _normalize_scrub_group_ids(
             data.get("scrub_mri_json_groups")
         )
+        export_phenotype_bridge = bool(data.get("export_phenotype_bridge", False))
         validation_mode = _normalize_export_validation_mode(
             data.get("validation_mode", "both")
         )
@@ -1066,6 +1069,7 @@ def export_project_start():
             "scrub_mri_json": scrub_mri_json,
             "scrub_mri_json_groups": scrub_mri_json_groups,
             "clean_nifti_gzip_headers": scrub_mri_json,
+            "export_phenotype_bridge": export_phenotype_bridge,
             "validation_mode": validation_mode,
             "exclude_subjects": exclude_subjects or None,
             "exclude_sessions": (

--- a/app/src/web/export_project.py
+++ b/app/src/web/export_project.py
@@ -233,6 +233,7 @@ def export_project(
     deface_anatomical_scans: bool = False,
     defacing_selected_variants: Optional[Set[str]] = None,
     clean_nifti_gzip_headers: bool = False,
+    export_phenotype_bridge: bool = False,
     progress_callback=None,
     cancelled_flag=None,
 ) -> Dict[str, Any]:
@@ -258,6 +259,10 @@ def export_project(
             defacing.
         clean_nifti_gzip_headers: Normalize .nii.gz GZIP headers (mtime/FNAME)
             in exported copies for privacy-safe sharing.
+        export_phenotype_bridge: Additionally aggregate survey/ data into a
+            vanilla BIDS phenotype/ directory in the export. This is a
+            compatibility escape hatch, not PRISM's native format - it is
+            lossy (instrument metadata like scale definitions is dropped).
         progress_callback: Optional callable(percent, message) for progress updates
         cancelled_flag: Optional threading.Event; set it to request cancellation
 
@@ -751,6 +756,46 @@ def export_project(
                     skip_tasks=exclude_tasks or None,
                     subject_name=item.name,
                 )
+
+            if export_phenotype_bridge:
+                _report(87, "Building phenotype/ compatibility bridge...")
+                _check_cancelled()
+                from src.converters.phenotype_export import collect_phenotype_bridge_files
+
+                phenotype_result = collect_phenotype_bridge_files(
+                    export_tree_root,
+                    exclude_subjects=normalized_exclude_subjects or None,
+                    exclude_sessions=exclude_sessions or None,
+                )
+                for warning in phenotype_result.warnings:
+                    print(f"  [phenotype export] {warning}")
+                for phenotype_file in phenotype_result.files:
+                    out_df = phenotype_file.dataframe.copy()
+                    if anonymize and participant_mapping and "participant_id" in out_df.columns:
+                        out_df["participant_id"] = out_df["participant_id"].map(
+                            lambda v: participant_mapping.get(v, v)
+                        )
+                    tsv_bytes = out_df.to_csv(
+                        sep="\t", index=False, lineterminator="\n"
+                    ).encode("utf-8")
+                    zipf.writestr(f"phenotype/{phenotype_file.name}.tsv", tsv_bytes)
+
+                    sidecar = phenotype_file.sidecar
+                    if mask_questions:
+                        sidecar = json.loads(json.dumps(sidecar))
+                        for column_name, item in sidecar.items():
+                            if column_name in ("participant_id", "session_id"):
+                                continue
+                            if not isinstance(item, dict) or "Description" not in item:
+                                continue
+                            item["Description"] = _masked_like(
+                                item.get("Description"), f"Question ({column_name})"
+                            )
+                    zipf.writestr(
+                        f"phenotype/{phenotype_file.name}.json",
+                        json.dumps(sidecar, indent=2, ensure_ascii=False).encode("utf-8"),
+                    )
+                    stats["files_processed"] += 2
 
             _report(88, "Adding root files...")
             _check_cancelled()

--- a/app/static/js/modules/projects/export.js
+++ b/app/static/js/modules/projects/export.js
@@ -356,6 +356,7 @@ function buildExportRequestData(currentProjectPath, overrides = {}) {
         mask_questions: getById('exportMaskQuestions')?.checked || false,
         scrub_mri_json: getById('exportScrubMriJson')?.checked || false,
         scrub_mri_json_groups: scrubGroups.length ? scrubGroups : null,
+        export_phenotype_bridge: getById('exportPhenotypeBridge')?.checked || false,
         include_derivatives: getById('exportDerivatives')?.checked || false,
         include_sourcedata: getById('exportSourcedata')?.checked || false,
         include_code: getById('exportCode')?.checked || false,

--- a/app/static/js/modules/projects/export.js
+++ b/app/static/js/modules/projects/export.js
@@ -414,6 +414,7 @@ function buildFolderExportRequestData(currentProjectPath) {
         output_folder: (getById('exportOutputFolder')?.value || '').trim() || null,
         scrub_mri_json: getById('exportScrubMriJson')?.checked || false,
         scrub_mri_json_groups: scrubGroups.length ? scrubGroups : null,
+        export_phenotype_bridge: getById('exportPhenotypeBridge')?.checked || false,
         include_derivatives: getById('exportDerivatives')?.checked || false,
         include_sourcedata: getById('exportSourcedata')?.checked || false,
         include_code: getById('exportCode')?.checked || false,

--- a/app/static/js/modules/projects/init-on-bids.js
+++ b/app/static/js/modules/projects/init-on-bids.js
@@ -364,6 +364,23 @@ export function initProjectInitOnBidsController({
                         </div>
                     `
                     : '';
+                const phenotypeImport = result.phenotype_import || null;
+                const phenotypeNotice = (phenotypeImport && phenotypeImport.imported_task_count)
+                    ? `
+                        <div class="alert alert-warning mt-3 mb-0">
+                            <i class="fas fa-triangle-exclamation me-2"></i>
+                            Detected a BIDS <code>phenotype/</code> directory and imported
+                            ${phenotypeImport.imported_task_count} task(s) into PRISM's native
+                            <code>survey/</code> layout as a one-way compatibility bridge.
+                            ${(phenotypeImport.flagged_columns && phenotypeImport.flagged_columns.length)
+                                ? `Column(s) that may belong in <code>participants.tsv</code> instead: ${escapeHtml(phenotypeImport.flagged_columns.join(', '))}.`
+                                : ''}
+                            Review the generated sidecars &mdash; instrument metadata (scale
+                            definitions, reverse-coding) could not be recovered from
+                            <code>phenotype/</code> and was left minimal.
+                        </div>
+                    `
+                    : '';
                 resultDiv.innerHTML = `
                     <div class="alert alert-success">
                         <h5><i class="fas fa-check-circle me-2"></i>PRISM Initialised Successfully!</h5>
@@ -385,6 +402,7 @@ export function initProjectInitOnBidsController({
                         ${sourceNotice}
                         ${dataladNotice}
                         ${environmentEnrichmentNotice}
+                        ${phenotypeNotice}
                     </div>
                 `;
                 applyCurrentProject(result.current_project);

--- a/app/templates/includes/projects/export_section.html
+++ b/app/templates/includes/projects/export_section.html
@@ -148,6 +148,24 @@
                                                             </div>
                                                         </div>
                                                     </div>
+
+                                                    <div class="col-12"><hr class="my-1"></div>
+
+                                                    <div class="form-check mb-2">
+                                                        <input class="form-check-input" type="checkbox" id="exportPhenotypeBridge">
+                                                        <label class="form-check-label fw-bold" for="exportPhenotypeBridge">
+                                                            Also export a BIDS <code>phenotype/</code> bridge
+                                                            <span class="badge bg-secondary ms-1" style="font-size:0.7em;">compatibility only</span>
+                                                        </label>
+                                                    </div>
+                                                    <div class="form-text ms-4 mt-1">
+                                                        Adds a vanilla BIDS <code>phenotype/</code> directory alongside PRISM's
+                                                        native <code>survey/</code> layout, for tools that only understand
+                                                        plain BIDS phenotype tables. This is a lossy, one-way compatibility
+                                                        export &mdash; instrument metadata (scale definitions, reverse-coding,
+                                                        acquisition variants) is not preserved. PRISM's own <code>survey/</code>
+                                                        data remains the authoritative copy.
+                                                    </div>
                                                     <div id="exportDefacingControls" style="display:none;">
                                                         <div class="mt-2 ms-4">
                                                             <div class="form-check mb-2">

--- a/src/converters/phenotype_export.py
+++ b/src/converters/phenotype_export.py
@@ -1,0 +1,271 @@
+"""Export PRISM survey/ data to a vanilla BIDS phenotype/ directory.
+
+This is a compatibility bridge, not PRISM's native survey format. PRISM
+stores survey data per-subject/session (``sub-*/ses-*/survey/*_survey.tsv``)
+because different acquisition variants of the same instrument can have
+different item sets and scale ranges (see ``VariantScales``/
+``ApplicableVersions`` in the survey schema) - a single wide
+``phenotype/<name>.tsv`` table cannot express that without either losing
+information or padding mismatched columns with NaNs. Exporting to
+phenotype/ is therefore intentionally lossy: only participant/session item
+*values* are guaranteed to transfer, not PRISM's richer instrument metadata
+(Reversed, MinValue/MaxValue, VariantDefinitions, Citation, ...).
+
+Each (TaskName, VariantID) pair becomes its own phenotype file so item sets
+and scales never get silently blended. Multiple runs of the same
+task/variant for one subject/session are not supported (no ``run-``
+equivalent in phenotype/); such cases are skipped and reported as warnings
+rather than guessed at.
+"""
+
+from __future__ import annotations
+
+import json
+import re
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Any, Optional
+
+import pandas as pd
+
+from src.bids_entity_parser import BidsEntityParser
+
+_SURVEY_FILENAME_PATTERN = re.compile(
+    # TaskName/VariantID allow internal hyphens (see survey.schema.json's
+    # TaskName pattern ^[a-zA-Z0-9][-a-zA-Z0-9]*$), unlike sub-/ses- labels.
+    r"^sub-(?P<subject>[A-Za-z0-9]+)_ses-(?P<session>[A-Za-z0-9]+)_"
+    r"task-(?P<task>[A-Za-z0-9][-A-Za-z0-9]*)(?:_acq-(?P<acq>[A-Za-z0-9][-A-Za-z0-9]*))?"
+    r"(?:_run-(?P<run>[A-Za-z0-9]+))?_survey\.tsv$"
+)
+
+@dataclass
+class PhenotypeExportFile:
+    """One phenotype/<name>.tsv + sidecar, ready to be written out."""
+
+    name: str
+    dataframe: pd.DataFrame
+    sidecar: dict[str, Any]
+
+
+@dataclass
+class PhenotypeExportResult:
+    """All phenotype files produced for a dataset, plus any skip warnings."""
+
+    files: list[PhenotypeExportFile] = field(default_factory=list)
+    warnings: list[str] = field(default_factory=list)
+
+
+def _parse_survey_filename(path: Path) -> Optional[dict[str, Optional[str]]]:
+    match = _SURVEY_FILENAME_PATTERN.match(path.name)
+    if match is None:
+        return None
+    return match.groupdict()
+
+
+def _discover_survey_files(
+    dataset_root: Path,
+    *,
+    exclude_subjects: Optional[set[str]] = None,
+    exclude_sessions: Optional[set[str]] = None,
+) -> list[Path]:
+    exclude_subjects = exclude_subjects or set()
+    exclude_sessions = exclude_sessions or set()
+    found: list[Path] = []
+    for subject_dir in sorted(dataset_root.glob("sub-*")):
+        if not subject_dir.is_dir() or subject_dir.name in exclude_subjects:
+            continue
+        for session_dir in sorted(subject_dir.glob("ses-*")):
+            if not session_dir.is_dir() or session_dir.name in exclude_sessions:
+                continue
+            survey_dir = session_dir / "survey"
+            if not survey_dir.is_dir():
+                continue
+            found.extend(sorted(survey_dir.glob("*_survey.tsv")))
+    return found
+
+
+def _group_survey_files(
+    survey_files: list[Path],
+) -> tuple[dict[tuple[str, Optional[str]], list[Path]], list[str]]:
+    """Group survey TSVs by (task, variant); flag any per-subject/session runs."""
+    groups: dict[tuple[str, Optional[str]], list[Path]] = {}
+    seen_subject_session: dict[tuple[str, Optional[str], str, str], Path] = {}
+    warnings: list[str] = []
+
+    for path in survey_files:
+        parsed = _parse_survey_filename(path)
+        if parsed is None:
+            warnings.append(f"Skipped unrecognized survey filename: {path.name}")
+            continue
+
+        task = parsed["task"]
+        variant = parsed["acq"]
+        subject = parsed["subject"]
+        session = parsed["session"]
+        assert task is not None and subject is not None and session is not None
+
+        dedup_key = (task, variant, subject, session)
+        if dedup_key in seen_subject_session:
+            warnings.append(
+                "Skipped multiple runs for the same subject/session/task/variant "
+                f"(phenotype/ has no run- equivalent): {path.name}"
+            )
+            continue
+        seen_subject_session[dedup_key] = path
+
+        groups.setdefault((task, variant), []).append(path)
+
+    return groups, warnings
+
+
+def _load_sidecars(
+    dataset_root: Path, task: str, variant: Optional[str]
+) -> tuple[dict[str, Any], dict[str, Any]]:
+    """Return (task-level sidecar, variant-level sidecar) parsed JSON, {} if missing."""
+    task_sidecar_path = dataset_root / f"task-{task}_survey.json"
+    task_sidecar = {}
+    if task_sidecar_path.is_file():
+        task_sidecar = json.loads(task_sidecar_path.read_text(encoding="utf-8"))
+
+    if variant:
+        variant_sidecar_path = dataset_root / f"task-{task}_acq-{variant}_survey.json"
+    else:
+        variant_sidecar_path = task_sidecar_path
+    variant_sidecar = task_sidecar
+    if variant_sidecar_path.is_file():
+        variant_sidecar = json.loads(variant_sidecar_path.read_text(encoding="utf-8"))
+
+    return task_sidecar, variant_sidecar
+
+
+def _item_levels_for_variant(item_def: dict[str, Any], variant: Optional[str]) -> Any:
+    if variant:
+        for scale in item_def.get("VariantScales") or []:
+            if scale.get("VariantID") == variant and "Levels" in scale:
+                return scale["Levels"]
+    return item_def.get("Levels")
+
+
+def build_phenotype_sidecar(
+    variant_sidecar: dict[str, Any],
+    columns: list[str],
+    *,
+    task: str,
+    variant: Optional[str],
+) -> dict[str, Any]:
+    """Reshape PRISM's nested survey sidecar into a flat, column-keyed dict.
+
+    Vanilla BIDS phenotype/ sidecars are plain ``{column_name: {Description,
+    Levels, ...}}`` maps, not PRISM's nested Technical/Study/Items structure -
+    only Description and Levels are meaningful to a generic BIDS consumer,
+    so everything else (Reversed, MinValue/MaxValue, Citation, ...) is
+    dropped rather than copied through.
+    """
+    sidecar: dict[str, Any] = {
+        "MeasurementToolMetadata": {
+            "PrismTaskName": task,
+            "PrismVariantID": variant,
+        }
+    }
+    for column in columns:
+        if column == "participant_id":
+            sidecar[column] = {"Description": "Participant identifier"}
+            continue
+        if column == "session_id":
+            sidecar[column] = {"Description": "Session identifier"}
+            continue
+
+        item_def = variant_sidecar.get(column)
+        if not isinstance(item_def, dict):
+            continue
+        entry: dict[str, Any] = {}
+        if "Description" in item_def:
+            entry["Description"] = item_def["Description"]
+        levels = _item_levels_for_variant(item_def, variant)
+        if levels:
+            entry["Levels"] = levels
+        if entry:
+            sidecar[column] = entry
+    return sidecar
+
+
+def _phenotype_file_name(task: str, variant: Optional[str], has_multiple_variants: bool) -> str:
+    if variant and has_multiple_variants:
+        return f"{task}-{variant}"
+    return task
+
+
+def collect_phenotype_bridge_files(
+    dataset_root: Path,
+    *,
+    exclude_subjects: Optional[set[str]] = None,
+    exclude_sessions: Optional[set[str]] = None,
+) -> PhenotypeExportResult:
+    """Aggregate PRISM survey/ data into one PhenotypeExportFile per (task, variant)."""
+    survey_files = _discover_survey_files(
+        dataset_root,
+        exclude_subjects=exclude_subjects,
+        exclude_sessions=exclude_sessions,
+    )
+    if not survey_files:
+        return PhenotypeExportResult()
+
+    groups, warnings = _group_survey_files(survey_files)
+    variants_per_task: dict[str, set[Optional[str]]] = {}
+    for task, variant in groups:
+        variants_per_task.setdefault(task, set()).add(variant)
+
+    results: list[PhenotypeExportFile] = []
+    for (task, variant), paths in groups.items():
+        rows: list[dict[str, Any]] = []
+        has_session = False
+        columns_order: list[str] = []
+
+        for path in paths:
+            parsed = _parse_survey_filename(path)
+            assert parsed is not None
+            subject_dir = path.parent.parent.parent
+            session_dir = path.parent.parent
+            subject_label = BidsEntityParser.subject_label_from_dir(subject_dir.name)
+            session_label = BidsEntityParser.session_label_from_dir(session_dir.name)
+
+            df = pd.read_csv(path, sep="\t", dtype=str)
+            if len(df) != 1:
+                warnings.append(
+                    f"Expected exactly one data row in {path.name}, found {len(df)}; skipped."
+                )
+                continue
+
+            row: dict[str, Any] = {"participant_id": f"sub-{subject_label}"}
+            if session_label:
+                row["session_id"] = f"ses-{session_label}"
+                has_session = True
+            row.update(df.iloc[0].to_dict())
+            rows.append(row)
+            for column in row:
+                if column not in columns_order:
+                    columns_order.append(column)
+
+        if not rows:
+            continue
+
+        if not has_session:
+            columns_order = [c for c in columns_order if c != "session_id"]
+
+        wide_df = pd.DataFrame(rows)
+        ordered_columns = [c for c in columns_order if c in wide_df.columns]
+        wide_df = wide_df[ordered_columns]
+
+        _task_sidecar, variant_sidecar = _load_sidecars(dataset_root, task, variant)
+        sidecar = build_phenotype_sidecar(
+            variant_sidecar, ordered_columns, task=task, variant=variant
+        )
+
+        name = _phenotype_file_name(
+            task, variant, has_multiple_variants=len(variants_per_task[task]) > 1
+        )
+        results.append(
+            PhenotypeExportFile(name=name, dataframe=wide_df, sidecar=sidecar)
+        )
+
+    return PhenotypeExportResult(files=results, warnings=warnings)

--- a/src/converters/phenotype_import.py
+++ b/src/converters/phenotype_import.py
@@ -1,0 +1,261 @@
+"""Import a vanilla BIDS phenotype/ directory into PRISM's survey/ layout.
+
+This is a compatibility bridge, not a replacement for PRISM's native survey
+converters (Excel/CSV/LimeSurvey). It intentionally does the minimum useful
+thing: every phenotype/*.tsv file becomes one PRISM task with no acquisition
+variant, every non-structural column becomes a survey item with only the
+metadata the phenotype .json sidecar (if any) actually provides - there is
+no attempt to fuzzy-match columns against the instrument library or to
+recover scale semantics (Reversed, MinValue/MaxValue, ...) that were never
+present in phenotype/ to begin with. Import is designed to run
+automatically and silently (see ProjectManager.init_on_existing_bids), so
+it must never guess in a way that could silently misrepresent data.
+"""
+
+from __future__ import annotations
+
+import json
+import re
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Any, Optional
+
+import pandas as pd
+
+_TASK_NAME_SANITIZE_PATTERN = re.compile(r"[^A-Za-z0-9-]+")
+_TASK_NAME_COLLAPSE_HYPHENS = re.compile(r"-{2,}")
+
+_STRUCTURAL_COLUMNS = ("participant_id", "session_id")
+
+_LIKELY_NON_ITEM_COLUMN_HINTS = {
+    "age",
+    "sex",
+    "gender",
+    "group",
+    "handedness",
+    "education",
+}
+
+DEFAULT_IMPORT_SESSION_LABEL = "import"
+
+
+@dataclass
+class PhenotypeImportSummary:
+    """Result of importing one or more phenotype/*.tsv files."""
+
+    created_files: list[str] = field(default_factory=list)
+    log: list[dict[str, str]] = field(default_factory=list)
+    imported_task_count: int = 0
+    flagged_columns: list[str] = field(default_factory=list)
+
+    def add_log(self, message: str, level: str = "info") -> None:
+        self.log.append({"message": message, "level": level})
+
+
+def sanitize_task_name_from_phenotype_filename(stem: str) -> str:
+    """Derive a PRISM-valid TaskName from a phenotype/<stem>.tsv filename.
+
+    TaskName allows internal hyphens (pattern ``^[a-zA-Z0-9][-a-zA-Z0-9]*$``),
+    so this is deliberately less aggressive than the physio-converter's
+    ``_sanitize_bids_label`` (which strips all non-alphanumerics including
+    hyphens): underscores/whitespace become hyphens instead of vanishing,
+    keeping multi-word measurement tool names readable.
+    """
+    name = stem.split("_desc-", 1)[0]
+    name = name.strip().lower().replace("_", "-")
+    name = re.sub(r"\s+", "-", name)
+    name = _TASK_NAME_SANITIZE_PATTERN.sub("", name)
+    name = _TASK_NAME_COLLAPSE_HYPHENS.sub("-", name)
+    name = name.strip("-")
+    return name or "phenotype"
+
+
+def flag_non_item_columns(columns: list[str]) -> list[str]:
+    """Return columns that look like they might belong in participants.tsv instead.
+
+    Advisory only - flagged columns are still imported as survey items
+    verbatim; this never auto-routes data into participants.tsv, which
+    would risk clobbering real participant-level data.
+    """
+    return [c for c in columns if c.lower() in _LIKELY_NON_ITEM_COLUMN_HINTS]
+
+
+def _build_minimal_sidecar(
+    task_name: str,
+    item_columns: list[str],
+    phenotype_sidecar: dict[str, Any],
+) -> dict[str, Any]:
+    items: dict[str, Any] = {}
+    for column in item_columns:
+        column_meta = phenotype_sidecar.get(column)
+        item_def: dict[str, Any] = {
+            "Description": column,
+            "Reversed": False,
+        }
+        if isinstance(column_meta, dict):
+            if column_meta.get("Description"):
+                item_def["Description"] = column_meta["Description"]
+            if column_meta.get("Levels"):
+                item_def["Levels"] = column_meta["Levels"]
+        items[column] = item_def
+
+    return {
+        "Technical": {
+            "StimulusType": "Questionnaire",
+            "FileFormat": "tsv",
+            "SoftwarePlatform": "",
+            "Language": "",
+            "Respondent": "self",
+            "AdministrationMethod": "",
+        },
+        "Metadata": {
+            "SchemaVersion": "1.2.0",
+            "CreationDate": "",
+        },
+        "Study": {
+            "TaskName": task_name,
+            "OriginalName": task_name,
+            "Citation": "Imported from a BIDS phenotype/ directory; no citation available.",
+            "LicenseID": "Other",
+        },
+        **items,
+    }
+
+
+def import_phenotype_file(
+    tsv_path: Path,
+    project_root: Path,
+    *,
+    json_path: Optional[Path] = None,
+    default_session_label: str = DEFAULT_IMPORT_SESSION_LABEL,
+) -> PhenotypeImportSummary:
+    """Import one phenotype/<name>.tsv (+ optional sidecar) into PRISM survey/."""
+    summary = PhenotypeImportSummary()
+
+    df = pd.read_csv(tsv_path, sep="\t", dtype=str)
+    if "participant_id" not in df.columns:
+        summary.add_log(
+            f"Skipped {tsv_path.name}: no 'participant_id' column found.",
+            "warning",
+        )
+        return summary
+
+    phenotype_sidecar: dict[str, Any] = {}
+    if json_path is not None and json_path.is_file():
+        phenotype_sidecar = json.loads(json_path.read_text(encoding="utf-8"))
+
+    task_name = sanitize_task_name_from_phenotype_filename(tsv_path.stem)
+    has_session_column = "session_id" in df.columns
+    item_columns = [c for c in df.columns if c not in _STRUCTURAL_COLUMNS]
+
+    flagged = flag_non_item_columns(item_columns)
+    if flagged:
+        summary.flagged_columns.extend(flagged)
+        summary.add_log(
+            f"Task '{task_name}': column(s) {', '.join(flagged)} look like "
+            "participant-level variables - consider moving them to "
+            "participants.tsv instead of keeping them as survey items.",
+            "warning",
+        )
+
+    if not has_session_column:
+        summary.add_log(
+            f"Task '{task_name}': phenotype/{tsv_path.name} has no session_id "
+            f"column; imported under a synthetic 'ses-{default_session_label}' "
+            "since PRISM's survey/ layout is organized per session.",
+            "warning",
+        )
+
+    written_any_row = False
+    for _, row in df.iterrows():
+        participant_id = str(row["participant_id"]).strip()
+        if not participant_id.startswith("sub-"):
+            summary.add_log(
+                f"Skipped row with unexpected participant_id '{participant_id}' "
+                f"in {tsv_path.name} (expected a 'sub-' prefix).",
+                "warning",
+            )
+            continue
+
+        if has_session_column:
+            session_id = str(row["session_id"]).strip()
+            if not session_id.startswith("ses-"):
+                summary.add_log(
+                    f"Skipped row with unexpected session_id '{session_id}' "
+                    f"in {tsv_path.name} (expected a 'ses-' prefix).",
+                    "warning",
+                )
+                continue
+        else:
+            session_id = f"ses-{default_session_label}"
+
+        survey_dir = project_root / participant_id / session_id / "survey"
+        survey_dir.mkdir(parents=True, exist_ok=True)
+        out_name = f"{participant_id}_{session_id}_task-{task_name}_survey.tsv"
+        out_path = survey_dir / out_name
+
+        row_df = pd.DataFrame([{c: row[c] for c in item_columns}])
+        row_df.to_csv(out_path, sep="\t", index=False, lineterminator="\n")
+        summary.created_files.append(
+            str(out_path.relative_to(project_root))
+        )
+        written_any_row = True
+
+    if not written_any_row:
+        return summary
+
+    sidecar_path = project_root / f"task-{task_name}_survey.json"
+    if not sidecar_path.is_file():
+        sidecar = _build_minimal_sidecar(task_name, item_columns, phenotype_sidecar)
+        sidecar_path.write_text(
+            json.dumps(sidecar, indent=2, ensure_ascii=False), encoding="utf-8"
+        )
+        summary.created_files.append(sidecar_path.name)
+
+    summary.imported_task_count = 1
+    summary.add_log(
+        f"Imported phenotype/{tsv_path.name} as PRISM task '{task_name}' "
+        f"({len(item_columns)} item column(s)).",
+        "success",
+    )
+    return summary
+
+
+def import_phenotype_directory(
+    phenotype_dir: Path,
+    project_root: Path,
+    *,
+    default_session_label: str = DEFAULT_IMPORT_SESSION_LABEL,
+) -> PhenotypeImportSummary:
+    """Import every phenotype/*.tsv file found in ``phenotype_dir``."""
+    aggregate = PhenotypeImportSummary()
+
+    for tsv_path in sorted(phenotype_dir.glob("*.tsv")):
+        json_path = tsv_path.with_suffix(".json")
+        file_summary = import_phenotype_file(
+            tsv_path,
+            project_root,
+            json_path=json_path if json_path.is_file() else None,
+            default_session_label=default_session_label,
+        )
+        aggregate.created_files.extend(file_summary.created_files)
+        aggregate.log.extend(file_summary.log)
+        aggregate.imported_task_count += file_summary.imported_task_count
+        aggregate.flagged_columns.extend(file_summary.flagged_columns)
+
+    if aggregate.imported_task_count:
+        aggregate.log.insert(
+            0,
+            {
+                "message": (
+                    f"Detected phenotype/ directory: imported "
+                    f"{aggregate.imported_task_count} task(s) into PRISM's "
+                    "survey/ layout as a compatibility bridge. Review the "
+                    "generated sidecars - metadata like scale definitions is "
+                    "not recoverable from phenotype/ and was left minimal."
+                ),
+                "level": "info",
+            },
+        )
+
+    return aggregate

--- a/tests/test_phenotype_export.py
+++ b/tests/test_phenotype_export.py
@@ -1,0 +1,130 @@
+from __future__ import annotations
+
+import json
+
+import pandas as pd
+
+from src.converters.phenotype_export import (
+    build_phenotype_sidecar,
+    collect_phenotype_bridge_files,
+)
+
+
+def _write_survey_tsv(base, subject, session, task, variant, values):
+    survey_dir = base / f"sub-{subject}" / f"ses-{session}" / "survey"
+    survey_dir.mkdir(parents=True, exist_ok=True)
+    acq_part = f"_acq-{variant}" if variant else ""
+    filename = f"sub-{subject}_ses-{session}_task-{task}{acq_part}_survey.tsv"
+    df = pd.DataFrame([values])
+    df.to_csv(survey_dir / filename, sep="\t", index=False, lineterminator="\n")
+
+
+def _write_sidecar(base, name, content):
+    (base / name).write_text(json.dumps(content), encoding="utf-8")
+
+
+def test_collect_phenotype_bridge_files_single_variant(tmp_path):
+    _write_survey_tsv(tmp_path, "01", "01", "wellbeing", None, {"WB01": 3, "WB02": 4})
+    _write_survey_tsv(tmp_path, "02", "01", "wellbeing", None, {"WB01": 5, "WB02": 2})
+    _write_sidecar(
+        tmp_path,
+        "task-wellbeing_survey.json",
+        {
+            "WB01": {"Description": "Item 1", "Levels": {"1": "Low", "5": "High"}},
+            "WB02": {"Description": "Item 2"},
+        },
+    )
+
+    result = collect_phenotype_bridge_files(tmp_path)
+
+    assert result.warnings == []
+    assert len(result.files) == 1
+    phenotype_file = result.files[0]
+    assert phenotype_file.name == "wellbeing"
+    assert list(phenotype_file.dataframe.columns) == [
+        "participant_id",
+        "session_id",
+        "WB01",
+        "WB02",
+    ]
+    rows = phenotype_file.dataframe.set_index("participant_id")
+    assert rows.loc["sub-01", "WB01"] == "3"
+    assert rows.loc["sub-02", "WB02"] == "2"
+    assert phenotype_file.sidecar["WB01"]["Description"] == "Item 1"
+    assert phenotype_file.sidecar["WB01"]["Levels"] == {"1": "Low", "5": "High"}
+
+
+def test_collect_phenotype_bridge_files_separates_variants(tmp_path):
+    _write_survey_tsv(tmp_path, "01", "01", "wellbeing", "10-likert", {"WB01": 3})
+    _write_survey_tsv(tmp_path, "01", "01", "wellbeing", "7-likert", {"WB01": 4})
+
+    result = collect_phenotype_bridge_files(tmp_path)
+
+    names = sorted(f.name for f in result.files)
+    assert names == ["wellbeing-10-likert", "wellbeing-7-likert"]
+
+
+def test_collect_phenotype_bridge_files_skips_duplicate_runs(tmp_path):
+    survey_dir = tmp_path / "sub-01" / "ses-01" / "survey"
+    survey_dir.mkdir(parents=True, exist_ok=True)
+    pd.DataFrame([{"WB01": 1}]).to_csv(
+        survey_dir / "sub-01_ses-01_task-wellbeing_run-1_survey.tsv",
+        sep="\t",
+        index=False,
+        lineterminator="\n",
+    )
+    pd.DataFrame([{"WB01": 2}]).to_csv(
+        survey_dir / "sub-01_ses-01_task-wellbeing_run-2_survey.tsv",
+        sep="\t",
+        index=False,
+        lineterminator="\n",
+    )
+
+    result = collect_phenotype_bridge_files(tmp_path)
+
+    assert len(result.files) == 1
+    assert any("run" in warning.lower() for warning in result.warnings)
+
+
+def test_collect_phenotype_bridge_files_respects_exclusions(tmp_path):
+    _write_survey_tsv(tmp_path, "01", "01", "wellbeing", None, {"WB01": 1})
+    _write_survey_tsv(tmp_path, "02", "01", "wellbeing", None, {"WB01": 2})
+
+    result = collect_phenotype_bridge_files(tmp_path, exclude_subjects={"sub-02"})
+
+    assert len(result.files) == 1
+    participant_ids = set(result.files[0].dataframe["participant_id"])
+    assert participant_ids == {"sub-01"}
+
+
+def test_collect_phenotype_bridge_files_no_surveys_returns_empty(tmp_path):
+    result = collect_phenotype_bridge_files(tmp_path)
+    assert result.files == []
+    assert result.warnings == []
+
+
+def test_build_phenotype_sidecar_drops_prism_specific_fields():
+    variant_sidecar = {
+        "WB01": {
+            "Description": "Item 1",
+            "Reversed": True,
+            "MinValue": 1,
+            "MaxValue": 5,
+            "Levels": {"1": "Low"},
+        }
+    }
+    sidecar = build_phenotype_sidecar(
+        variant_sidecar,
+        ["participant_id", "session_id", "WB01"],
+        task="wellbeing",
+        variant=None,
+    )
+
+    assert sidecar["WB01"] == {"Description": "Item 1", "Levels": {"1": "Low"}}
+    assert "Reversed" not in sidecar["WB01"]
+    assert "MinValue" not in sidecar["WB01"]
+    assert sidecar["participant_id"] == {"Description": "Participant identifier"}
+    assert sidecar["MeasurementToolMetadata"] == {
+        "PrismTaskName": "wellbeing",
+        "PrismVariantID": None,
+    }

--- a/tests/test_phenotype_import.py
+++ b/tests/test_phenotype_import.py
@@ -1,0 +1,162 @@
+from __future__ import annotations
+
+import json
+
+import pandas as pd
+
+from src.converters.phenotype_import import (
+    flag_non_item_columns,
+    import_phenotype_directory,
+    import_phenotype_file,
+    sanitize_task_name_from_phenotype_filename,
+)
+
+
+def test_sanitize_task_name_keeps_hyphens_and_lowercases():
+    assert sanitize_task_name_from_phenotype_filename("Wellbeing_Multi") == "wellbeing-multi"
+
+
+def test_sanitize_task_name_strips_desc_suffix():
+    assert sanitize_task_name_from_phenotype_filename("demographics_desc-baseline") == "demographics"
+
+
+def test_sanitize_task_name_strips_disallowed_characters():
+    assert sanitize_task_name_from_phenotype_filename("A survey!! (v2)") == "a-survey-v2"
+
+
+def test_sanitize_task_name_falls_back_when_empty():
+    assert sanitize_task_name_from_phenotype_filename("___") == "phenotype"
+
+
+def test_flag_non_item_columns_matches_stoplist():
+    flagged = flag_non_item_columns(["WB01", "age", "WB02", "handedness"])
+    assert flagged == ["age", "handedness"]
+
+
+def test_import_phenotype_file_with_session_column(tmp_path):
+    phenotype_dir = tmp_path / "phenotype"
+    phenotype_dir.mkdir()
+    tsv_path = phenotype_dir / "wellbeing.tsv"
+    pd.DataFrame(
+        [
+            {"participant_id": "sub-01", "session_id": "ses-01", "WB01": 3, "WB02": 4},
+            {"participant_id": "sub-02", "session_id": "ses-01", "WB01": 5, "WB02": 2},
+        ]
+    ).to_csv(tsv_path, sep="\t", index=False, lineterminator="\n")
+
+    project_root = tmp_path / "project"
+    project_root.mkdir()
+
+    summary = import_phenotype_file(tsv_path, project_root)
+
+    out_tsv = (
+        project_root
+        / "sub-01"
+        / "ses-01"
+        / "survey"
+        / "sub-01_ses-01_task-wellbeing_survey.tsv"
+    )
+    assert out_tsv.is_file()
+    out_df = pd.read_csv(out_tsv, sep="\t", dtype=str)
+    assert list(out_df.columns) == ["WB01", "WB02"]
+    assert out_df.iloc[0]["WB01"] == "3"
+
+    sidecar_path = project_root / "task-wellbeing_survey.json"
+    assert sidecar_path.is_file()
+    sidecar = json.loads(sidecar_path.read_text(encoding="utf-8"))
+    assert sidecar["Study"]["TaskName"] == "wellbeing"
+    assert "WB01" in sidecar
+
+    assert summary.imported_task_count == 1
+
+
+def test_import_phenotype_file_without_session_column_synthesizes_session(tmp_path):
+    phenotype_dir = tmp_path / "phenotype"
+    phenotype_dir.mkdir()
+    tsv_path = phenotype_dir / "demographics.tsv"
+    pd.DataFrame([{"participant_id": "sub-01", "age": 30}]).to_csv(
+        tsv_path, sep="\t", index=False, lineterminator="\n"
+    )
+
+    project_root = tmp_path / "project"
+    project_root.mkdir()
+
+    summary = import_phenotype_file(tsv_path, project_root)
+
+    out_tsv = (
+        project_root
+        / "sub-01"
+        / "ses-import"
+        / "survey"
+        / "sub-01_ses-import_task-demographics_survey.tsv"
+    )
+    assert out_tsv.is_file()
+    assert any("ses-import" in entry["message"] for entry in summary.log)
+    assert "age" in summary.flagged_columns
+
+
+def test_import_phenotype_file_uses_sidecar_description_and_levels(tmp_path):
+    phenotype_dir = tmp_path / "phenotype"
+    phenotype_dir.mkdir()
+    tsv_path = phenotype_dir / "wellbeing.tsv"
+    pd.DataFrame(
+        [{"participant_id": "sub-01", "session_id": "ses-01", "WB01": 3}]
+    ).to_csv(tsv_path, sep="\t", index=False, lineterminator="\n")
+    json_path = phenotype_dir / "wellbeing.json"
+    json_path.write_text(
+        json.dumps({"WB01": {"Description": "How happy are you?", "Levels": {"1": "Low"}}}),
+        encoding="utf-8",
+    )
+
+    project_root = tmp_path / "project"
+    project_root.mkdir()
+
+    import_phenotype_file(tsv_path, project_root, json_path=json_path)
+
+    sidecar = json.loads(
+        (project_root / "task-wellbeing_survey.json").read_text(encoding="utf-8")
+    )
+    assert sidecar["WB01"]["Description"] == "How happy are you?"
+    assert sidecar["WB01"]["Levels"] == {"1": "Low"}
+
+
+def test_import_phenotype_file_skips_rows_with_bad_participant_id(tmp_path):
+    phenotype_dir = tmp_path / "phenotype"
+    phenotype_dir.mkdir()
+    tsv_path = phenotype_dir / "wellbeing.tsv"
+    pd.DataFrame(
+        [
+            {"participant_id": "sub-01", "session_id": "ses-01", "WB01": 3},
+            {"participant_id": "not-a-subject", "session_id": "ses-01", "WB01": 9},
+        ]
+    ).to_csv(tsv_path, sep="\t", index=False, lineterminator="\n")
+
+    project_root = tmp_path / "project"
+    project_root.mkdir()
+
+    summary = import_phenotype_file(tsv_path, project_root)
+
+    assert (project_root / "sub-01").is_dir()
+    assert not (project_root / "not-a-subject").exists()
+    assert any("Skipped row" in entry["message"] for entry in summary.log)
+
+
+def test_import_phenotype_directory_imports_all_files(tmp_path):
+    phenotype_dir = tmp_path / "phenotype"
+    phenotype_dir.mkdir()
+    pd.DataFrame(
+        [{"participant_id": "sub-01", "session_id": "ses-01", "WB01": 1}]
+    ).to_csv(phenotype_dir / "wellbeing.tsv", sep="\t", index=False, lineterminator="\n")
+    pd.DataFrame(
+        [{"participant_id": "sub-01", "session_id": "ses-01", "PHQ01": 2}]
+    ).to_csv(phenotype_dir / "phq9.tsv", sep="\t", index=False, lineterminator="\n")
+
+    project_root = tmp_path / "project"
+    project_root.mkdir()
+
+    summary = import_phenotype_directory(phenotype_dir, project_root)
+
+    assert summary.imported_task_count == 2
+    assert (project_root / "task-wellbeing_survey.json").is_file()
+    assert (project_root / "task-phq9_survey.json").is_file()
+    assert summary.log[0]["message"].startswith("Detected phenotype/ directory")

--- a/tests/test_phenotype_roundtrip.py
+++ b/tests/test_phenotype_roundtrip.py
@@ -1,0 +1,162 @@
+"""Round-trip regression test for the phenotype/ compatibility bridge.
+
+phenotype/ is a lossy, one-way-friendly bridge by design (see
+src/converters/phenotype_export.py and phenotype_import.py docstrings): the
+only guarantee is that item *values* survive an export-then-import
+round-trip. PRISM's richer instrument metadata (VariantDefinitions,
+VariantScales, Reversed, MinValue/MaxValue, Citation, ...) is not expected
+to survive, and this test asserts that loss explicitly rather than only
+checking that the round-tripped data is "still importable" - a test that
+only checked that could mask a regression that starts silently over- or
+under-preserving metadata.
+"""
+
+from __future__ import annotations
+
+import json
+
+import pandas as pd
+
+from src.converters.phenotype_export import collect_phenotype_bridge_files
+from src.converters.phenotype_import import import_phenotype_directory
+
+
+def _write_source_dataset(base):
+    """Build a small PRISM survey/ tree: 2 subjects x 2 sessions, one task+variant."""
+    sidecar = {
+        "Technical": {"StimulusType": "Questionnaire", "FileFormat": "tsv"},
+        "Metadata": {"SchemaVersion": "1.2.0", "CreationDate": "2026-01-01"},
+        "Study": {
+            "TaskName": "wellbeing-multi",
+            "Versions": ["10-likert"],
+            "VariantDefinitions": [
+                {"VariantID": "10-likert", "ItemCount": 2, "ScaleType": "likert"}
+            ],
+            "Citation": "Demo citation, expected to be lost on round-trip.",
+        },
+        "WB01": {
+            "Description": "I have felt cheerful",
+            "Reversed": False,
+            "MinValue": 1,
+            "MaxValue": 5,
+            "Levels": {"1": "Strongly disagree", "5": "Strongly agree"},
+            "VariantScales": [
+                {
+                    "VariantID": "10-likert",
+                    "Levels": {"1": "Strongly disagree", "5": "Strongly agree"},
+                }
+            ],
+        },
+        "WB02": {
+            "Description": "I have felt calm",
+            "Reversed": True,
+            "MinValue": 1,
+            "MaxValue": 5,
+        },
+    }
+    (base / "task-wellbeing-multi_acq-10-likert_survey.json").write_text(
+        json.dumps(sidecar), encoding="utf-8"
+    )
+
+    rows = {
+        ("01", "01"): {"WB01": 4, "WB02": 2},
+        ("01", "02"): {"WB01": 3, "WB02": 5},
+        ("02", "01"): {"WB01": 5, "WB02": 1},
+    }
+    for (subject, session), values in rows.items():
+        survey_dir = base / f"sub-{subject}" / f"ses-{session}" / "survey"
+        survey_dir.mkdir(parents=True, exist_ok=True)
+        filename = (
+            f"sub-{subject}_ses-{session}_task-wellbeing-multi_acq-10-likert_survey.tsv"
+        )
+        pd.DataFrame([values]).to_csv(
+            survey_dir / filename, sep="\t", index=False, lineterminator="\n"
+        )
+    return rows
+
+
+def _source_value_matrix(base, rows):
+    matrix = {}
+    for (subject, session) in rows:
+        path = (
+            base
+            / f"sub-{subject}"
+            / f"ses-{session}"
+            / "survey"
+            / f"sub-{subject}_ses-{session}_task-wellbeing-multi_acq-10-likert_survey.tsv"
+        )
+        df = pd.read_csv(path, sep="\t", dtype=str)
+        matrix[(subject, session)] = df.iloc[0].to_dict()
+    return matrix
+
+
+def test_survey_to_phenotype_to_survey_roundtrips_item_values(tmp_path):
+    source_root = tmp_path / "source"
+    source_root.mkdir()
+    rows = _write_source_dataset(source_root)
+    source_values = _source_value_matrix(source_root, rows)
+
+    export_result = collect_phenotype_bridge_files(source_root)
+    assert len(export_result.files) == 1
+    phenotype_file = export_result.files[0]
+    # Only one variant ("10-likert") is present in the source dataset, so the
+    # variant suffix is omitted (it's only added to disambiguate when a task
+    # has multiple variants - see test_collect_phenotype_bridge_files_separates_variants).
+    assert phenotype_file.name == "wellbeing-multi"
+
+    phenotype_dir = tmp_path / "phenotype"
+    phenotype_dir.mkdir()
+    phenotype_file.dataframe.to_csv(
+        phenotype_dir / f"{phenotype_file.name}.tsv",
+        sep="\t",
+        index=False,
+        lineterminator="\n",
+    )
+    (phenotype_dir / f"{phenotype_file.name}.json").write_text(
+        json.dumps(phenotype_file.sidecar), encoding="utf-8"
+    )
+
+    reimport_root = tmp_path / "reimported"
+    reimport_root.mkdir()
+    import_summary = import_phenotype_directory(phenotype_dir, reimport_root)
+    assert import_summary.imported_task_count == 1
+
+    # Data fidelity: every (subject, session, item) value must survive intact.
+    imported_task_name = "wellbeing-multi"
+    for (subject, session), original_values in source_values.items():
+        imported_path = (
+            reimport_root
+            / f"sub-{subject}"
+            / f"ses-{session}"
+            / "survey"
+            / f"sub-{subject}_ses-{session}_task-{imported_task_name}_survey.tsv"
+        )
+        assert imported_path.is_file()
+        imported_df = pd.read_csv(imported_path, sep="\t", dtype=str)
+        imported_row = imported_df.iloc[0].to_dict()
+        for item, value in original_values.items():
+            assert imported_row[item] == str(value)
+
+    # Metadata loss: explicitly assert what is NOT preserved, so a future
+    # change that starts silently over-preserving (or further under-
+    # preserving) metadata is caught rather than passing quietly. Note:
+    # TaskName itself round-trips unchanged here because it was already a
+    # valid PRISM TaskName to begin with (sanitization is a no-op for names
+    # produced by our own exporter) - sanitization actually kicking in for
+    # arbitrary/non-PRISM phenotype filenames is covered separately in
+    # test_phenotype_import.py's test_sanitize_task_name_* tests.
+    reimported_sidecar = json.loads(
+        (reimport_root / f"task-{imported_task_name}_survey.json").read_text(
+            encoding="utf-8"
+        )
+    )
+    assert reimported_sidecar["Study"]["TaskName"] == "wellbeing-multi"
+    assert (
+        reimported_sidecar["Study"]["Citation"]
+        != "Demo citation, expected to be lost on round-trip."
+    )
+    assert "VariantDefinitions" not in reimported_sidecar["Study"]
+    assert "Reversed" not in reimported_sidecar.get("WB02", {}) or reimported_sidecar[
+        "WB02"
+    ].get("Reversed") is False
+    assert "MinValue" not in reimported_sidecar.get("WB01", {})


### PR DESCRIPTION
## Summary
- v1.16.0 (native window + security hardening) landed on main via #77
- Per maintainer decision, the git tag for v1.16.0 is deliberately held until the full strategic roadmap (Phases 1-5) is complete, so this documents that in ROADMAP.md

## Test plan
- [x] Documentation-only change; no code paths affected