### PR TITLE
Add provenance to recipe-computed derivatives (Phase 2)

### DIFF
--- a/src/recipes_surveys.py
+++ b/src/recipes_surveys.py
@@ -19,10 +19,16 @@ from dataclasses import dataclass
 from datetime import datetime
 from pathlib import Path
 import csv
+import hashlib
 import re
 import json
 from typing import Any, Dict, Optional
 
+from src.datalad_execution import (
+    is_datalad_dataset,
+    resolve_datalad_executable,
+    run_datalad_save,
+)
 from src.recipes_formula_engine import (
     _calculate_derived_variables,
     _calculate_scores,
@@ -784,11 +790,23 @@ def _apply_survey_derivative_recipe_to_rows(
 def _write_recipes_dataset_description(
     *, out_root: Path, modality: str, prism_root: Path
 ) -> None:
-    """Create a dataset_description.json under derivatives/<modality>/."""
+    """Create or refresh dataset_description.json under derivatives/<modality>/.
+
+    Provenance fields (GeneratedBy, SourceDatasets, GeneratedOn) are always
+    recomputed so re-runs reflect the actual PRISM version and timestamp.
+    Everything else (Name, Description, BIDSVersion, DatasetType, Authors,
+    License, HowToAcknowledge, Funding) is only filled in when absent, so a
+    user's hand-edit to this file survives subsequent recipe runs.
+    """
+    from src import __version__ as prism_version
 
     desc_path = out_root / "dataset_description.json"
+    existing: dict = {}
     if desc_path.exists():
-        return
+        try:
+            existing = _read_json(desc_path)
+        except Exception:
+            existing = {}
 
     # Try to inherit some metadata from the root dataset_description.json
     root_desc_path = prism_root / "dataset_description.json"
@@ -801,15 +819,12 @@ def _write_recipes_dataset_description(
             pass
 
     modality_label = modality.capitalize()
-    obj = {
-        "Name": f"{root_meta.get('Name', 'PRISM')} {modality_label} Recipes",
-        "BIDSVersion": "1.8.0",
-        "DatasetType": "derivative",
+    provenance_fields = {
         "GeneratedBy": [
             {
                 "Name": "prism-tools",
                 "Description": f"{modality_label} recipe scoring (reverse coding, subscales, formulas)",
-                "Version": "1.0.0",
+                "Version": prism_version,
                 "CodeURL": "https://github.com/MRI-Lab-Graz/prism-studio",
             }
         ],
@@ -822,12 +837,85 @@ def _write_recipes_dataset_description(
         "GeneratedOn": datetime.now().isoformat(timespec="seconds"),
     }
 
-    # Copy relevant fields from root
+    default_fields = {
+        "Name": f"{root_meta.get('Name', 'PRISM')} {modality_label} Recipes",
+        "BIDSVersion": "1.8.0",
+        "DatasetType": "derivative",
+    }
     for field in ["Authors", "License", "HowToAcknowledge", "Funding"]:
         if field in root_meta:
-            obj[field] = root_meta[field]
+            default_fields[field] = root_meta[field]
+
+    obj = {**default_fields, **existing, **provenance_fields}
 
     _write_json(desc_path, obj)
+
+
+def _hash_file_sha256(
+    path: Path, *, cache: dict[Path, str] | None = None, chunk_size: int = 1 << 20
+) -> str:
+    """Streaming sha256 hex digest of a file.
+
+    ``cache`` should be a dict created fresh per compute_survey_recipes()
+    call (never a module-level dict): a file consumed by multiple recipes
+    within the same run (e.g. participants.tsv) is then hashed once instead
+    of once per recipe, without risking a stale hash across separate calls
+    in a long-running process if the file's content changes between runs.
+    """
+    resolved = path.resolve()
+    if cache is not None and resolved in cache:
+        return cache[resolved]
+
+    digest = hashlib.sha256()
+    with open(resolved, "rb") as f:
+        for chunk in iter(lambda: f.read(chunk_size), b""):
+            digest.update(chunk)
+    hex_digest = digest.hexdigest()
+    if cache is not None:
+        cache[resolved] = hex_digest
+    return hex_digest
+
+
+def _write_recipe_provenance_sidecar(
+    *,
+    out_root: Path,
+    recipe_id: str,
+    recipe: dict,
+    prism_root: Path,
+    input_files: list[Path],
+    participants_files: list[Path],
+    hash_cache: dict[Path, str],
+) -> None:
+    """Write a per-recipe provenance sidecar recording exact inputs and versions.
+
+    Written directly under out_root (not co-located with each format's own
+    output layout, which varies: a subfolder per recipe for "prism" format,
+    a flat per-recipe file for csv/xlsx/sav, a single dataset-wide file for
+    "flat") so there is one predictable location regardless of out_format.
+    """
+    from src import __version__ as prism_version
+
+    def _describe(paths: list[Path]) -> list[dict[str, str]]:
+        described = []
+        for p in paths:
+            try:
+                rel_path = p.resolve().relative_to(prism_root.resolve()).as_posix()
+            except ValueError:
+                rel_path = str(p)
+            described.append(
+                {"Path": rel_path, "SHA256": _hash_file_sha256(p, cache=hash_cache)}
+            )
+        return described
+
+    provenance = {
+        "RecipeId": recipe_id,
+        "RecipeVersion": recipe.get("RecipeVersion"),
+        "GeneratedBy": {"Name": "prism-tools", "Version": prism_version},
+        "GeneratedOn": datetime.now().isoformat(timespec="seconds"),
+        "InputFiles": _describe(input_files),
+        "ParticipantsFiles": _describe(participants_files),
+    }
+    _write_json(out_root / f"{recipe_id}_provenance.json", provenance)
 
 
 def _generate_recipes_boilerplate_sections(
@@ -2002,6 +2090,7 @@ def compute_survey_recipes(
     written_recipe_ids: set[str] = set()
     raw_only_tasks: set[str] = set()
     matched_task_ids: set[str] = set()
+    recipe_inputs: dict[str, list[Path]] = {}
 
     flat_out_path: Path | None = None
     fallback_note: str | None = None
@@ -2038,6 +2127,7 @@ def compute_survey_recipes(
 
         applied_recipe_ids.add(recipe_id)
         applied_recipes_list.append(recipe)
+        recipe_inputs[recipe_id] = list(matching)
 
         if out_format in ("csv", "xlsx", "sav"):
             if merge_all:
@@ -2591,6 +2681,30 @@ def compute_survey_recipes(
     _write_recipes_dataset_description(
         out_root=out_root, modality=modality, prism_root=output_prism_root
     )
+
+    participants_files = [
+        p
+        for p in (
+            output_prism_root / "participants.tsv",
+            output_prism_root / "participants.json",
+        )
+        if p.is_file()
+    ]
+    hash_cache: dict[Path, str] = {}
+    for recipe_id in sorted(written_recipe_ids):
+        input_files = recipe_inputs.get(recipe_id)
+        if not input_files:
+            continue
+        _write_recipe_provenance_sidecar(
+            out_root=out_root,
+            recipe_id=recipe_id,
+            recipe=recipes[recipe_id]["json"],
+            prism_root=output_prism_root,
+            input_files=input_files,
+            participants_files=participants_files,
+            hash_cache=hash_cache,
+        )
+
     _ensure_bidsignore_prism_rules(output_prism_root, modality)
 
     if boilerplate and applied_recipes_list:
@@ -2599,6 +2713,33 @@ def compute_survey_recipes(
             applied_recipes=applied_recipes_list, out_path=boilerplate_path, lang=lang
         )
         boilerplate_html_path = boilerplate_path.with_suffix(".html")
+
+    if is_datalad_dataset(output_prism_root):
+        datalad_executable = resolve_datalad_executable()
+        if not datalad_executable:
+            raise ValueError(
+                "This project is tracked by DataLad and recipe scoring changes "
+                "require DataLad. Install with: uv tool install datalad git-annex."
+            )
+        # Scope the save to everything this run actually touched: the
+        # derivative output tree, the seeded recipe copies under code/, and
+        # .bidsignore (all written above) - not an unscoped `-r` save, which
+        # would walk every registered subdataset on every recipe run.
+        save_paths = [str(out_root.relative_to(output_prism_root))]
+        if recipes_seeded:
+            save_paths.append(str(Path("code") / "recipes" / modality))
+        if (output_prism_root / ".bidsignore").exists():
+            save_paths.append(".bidsignore")
+        save_result = run_datalad_save(
+            output_prism_root,
+            message=f"PRISM: compute {modality} recipes ({out_format})",
+            datalad_executable=datalad_executable,
+            paths=save_paths,
+        )
+        if not save_result.get("success"):
+            raise ValueError(
+                str(save_result.get("message") or "DataLad save failed after recipe scoring.")
+            )
 
     return SurveyRecipesResult(
         processed_files=processed_files,

--- a/tests/test_recipes_datalad_save.py
+++ b/tests/test_recipes_datalad_save.py
@@ -1,0 +1,135 @@
+"""Tests for the DataLad `save` step after recipe scoring.
+
+Recipe scoring runs in-process as before; the only DataLad-aware addition
+is a scoped `datalad save` at the end when the project is DataLad-tracked
+(see src/recipes_surveys.py). This deliberately avoids `datalad run` -
+see the module docstring context in the roadmap for why.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from src.recipes_surveys import compute_survey_recipes
+
+
+def _setup_minimal_project(tmp_path: Path, task_name: str = "test") -> tuple[Path, Path]:
+    """Create a minimal PRISM project with one survey file and recipe."""
+    project_root = tmp_path / "project"
+    recipe_dir = tmp_path / "recipes"
+
+    survey_dir = project_root / "sub-001" / "ses-1" / "survey"
+    survey_dir.mkdir(parents=True)
+    survey_tsv = survey_dir / f"sub-001_ses-1_task-{task_name}_survey.tsv"
+    survey_tsv.write_text("Q1\n5\n", encoding="utf-8")
+
+    recipe_dir.mkdir(parents=True)
+    (recipe_dir / f"recipe-{task_name}.json").write_text(
+        (
+            "{\n"
+            '  "Kind": "survey",\n'
+            '  "RecipeVersion": "1.0",\n'
+            f'  "Survey": {{"TaskName": "{task_name}"}},\n'
+            '  "Scores": [\n'
+            '    {"Name": "Total", "Method": "sum", "Items": ["Q1"]}\n'
+            "  ]\n"
+            "}\n"
+        ),
+        encoding="utf-8",
+    )
+
+    return project_root, recipe_dir
+
+
+def test_compute_survey_recipes_skips_datalad_for_plain_project(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """A project with no .datalad/ marker never touches DataLad at all."""
+    project_root, recipe_dir = _setup_minimal_project(tmp_path)
+
+    def _fail_if_called(*args, **kwargs):
+        raise AssertionError("resolve_datalad_executable should not be called")
+
+    monkeypatch.setattr(
+        "src.recipes_surveys.resolve_datalad_executable", _fail_if_called
+    )
+
+    result = compute_survey_recipes(
+        prism_root=project_root,
+        repo_root=tmp_path,
+        recipe_dir=recipe_dir,
+        modality="survey",
+        out_format="csv",
+    )
+
+    assert result.out_root.exists()
+
+
+def test_compute_survey_recipes_calls_datalad_save_when_tracked(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """A DataLad-tracked project gets a scoped `datalad save` after scoring."""
+    project_root, recipe_dir = _setup_minimal_project(tmp_path)
+    (project_root / ".datalad").mkdir(parents=True)
+
+    monkeypatch.setattr(
+        "src.recipes_surveys.resolve_datalad_executable", lambda: "datalad"
+    )
+
+    captured_commands: list[list[str]] = []
+
+    def _fake_run(command, cwd=None, capture_output=True, text=True, timeout=None, check=False):
+        captured_commands.append(list(command))
+
+        class _Proc:
+            returncode = 0
+            stdout = ""
+            stderr = ""
+
+        return _Proc()
+
+    monkeypatch.setattr("src.datalad_execution.subprocess.run", _fake_run)
+
+    result = compute_survey_recipes(
+        prism_root=project_root,
+        repo_root=tmp_path,
+        recipe_dir=recipe_dir,
+        modality="survey",
+        out_format="csv",
+    )
+
+    assert len(captured_commands) == 1
+    save_command = captured_commands[0]
+    assert save_command[:2] == ["datalad", "save"]
+    assert "-m" in save_command
+    message_index = save_command.index("-m") + 1
+    assert "recipes" in save_command[message_index]
+    # Scoped to the paths this run actually touched (derivative output +
+    # seeded recipe copy), not an unscoped whole-dataset save.
+    relative_out_root = str(result.out_root.relative_to(project_root))
+    assert relative_out_root in save_command
+    assert str(Path("code") / "recipes" / "survey") in save_command
+    assert "." not in save_command
+
+
+def test_compute_survey_recipes_raises_when_datalad_tracked_but_missing_tool(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """DataLad-tracked project with no datalad executable fails loudly, not silently."""
+    project_root, recipe_dir = _setup_minimal_project(tmp_path)
+    (project_root / ".datalad").mkdir(parents=True)
+
+    monkeypatch.setattr(
+        "src.recipes_surveys.resolve_datalad_executable", lambda: None
+    )
+
+    with pytest.raises(ValueError, match="require DataLad"):
+        compute_survey_recipes(
+            prism_root=project_root,
+            repo_root=tmp_path,
+            recipe_dir=recipe_dir,
+            modality="survey",
+            out_format="csv",
+        )

--- a/tests/test_recipes_output_subfolder.py
+++ b/tests/test_recipes_output_subfolder.py
@@ -8,6 +8,8 @@ The output subfolder is determined by layout, language, and anonymization settin
 from pathlib import Path
 from typing import Any
 import csv
+import hashlib
+import json
 
 import pytest
 
@@ -636,6 +638,104 @@ class TestOutputFilesInSubfolder:
 
         desc_file = result.out_root / "dataset_description.json"
         assert desc_file.exists()
+
+    def test_dataset_description_generated_by_uses_real_version(
+        self, tmp_path: Path
+    ) -> None:
+        """GeneratedBy.Version reflects the actual PRISM version, not a hardcoded one."""
+        from src import __version__ as prism_version
+
+        project_root, recipe_dir = _setup_minimal_project(tmp_path)
+
+        result = compute_survey_recipes(
+            prism_root=project_root,
+            repo_root=tmp_path,
+            recipe_dir=recipe_dir,
+            modality="survey",
+            out_format="csv",
+        )
+
+        desc_file = result.out_root / "dataset_description.json"
+        desc = json.loads(desc_file.read_text(encoding="utf-8"))
+        assert desc["GeneratedBy"][0]["Version"] == prism_version
+
+    def test_dataset_description_updates_but_preserves_hand_edits_on_rerun(
+        self, tmp_path: Path
+    ) -> None:
+        """Re-running recipes refreshes provenance fields but keeps user edits."""
+        project_root, recipe_dir = _setup_minimal_project(tmp_path)
+
+        result = compute_survey_recipes(
+            prism_root=project_root,
+            repo_root=tmp_path,
+            recipe_dir=recipe_dir,
+            modality="survey",
+            out_format="csv",
+        )
+        desc_file = result.out_root / "dataset_description.json"
+        desc = json.loads(desc_file.read_text(encoding="utf-8"))
+        # Stale sentinel values, not a real prior timestamp/version: proves the
+        # re-run actually recomputes these fields rather than keeping whatever
+        # was already on disk (a real-clock comparison would be flaky if both
+        # runs land in the same second).
+        desc["Name"] = "My Custom Derivative Name"
+        desc["GeneratedOn"] = "2000-01-01T00:00:00"
+        desc["GeneratedBy"][0]["Version"] = "0.0.0-stale"
+        desc_file.write_text(json.dumps(desc), encoding="utf-8")
+
+        compute_survey_recipes(
+            prism_root=project_root,
+            repo_root=tmp_path,
+            recipe_dir=recipe_dir,
+            modality="survey",
+            out_format="csv",
+        )
+        updated = json.loads(desc_file.read_text(encoding="utf-8"))
+
+        assert updated["Name"] == "My Custom Derivative Name"
+        assert updated["GeneratedOn"] != "2000-01-01T00:00:00"
+        assert updated["GeneratedBy"][0]["Version"] != "0.0.0-stale"
+
+    def test_recipe_provenance_sidecar_written(self, tmp_path: Path) -> None:
+        """A per-recipe provenance sidecar records exact input file hashes."""
+        project_root, recipe_dir = _setup_minimal_project(tmp_path)
+        survey_tsv = (
+            project_root
+            / "sub-001"
+            / "ses-1"
+            / "survey"
+            / "sub-001_ses-1_task-test_survey.tsv"
+        )
+
+        (project_root / "participants.tsv").write_text(
+            "participant_id\tage\nsub-001\t30\n", encoding="utf-8"
+        )
+
+        result = compute_survey_recipes(
+            prism_root=project_root,
+            repo_root=tmp_path,
+            recipe_dir=recipe_dir,
+            modality="survey",
+            out_format="csv",
+        )
+
+        provenance_file = result.out_root / "test_provenance.json"
+        assert provenance_file.exists()
+        provenance = json.loads(provenance_file.read_text(encoding="utf-8"))
+
+        assert provenance["RecipeId"] == "test"
+        assert provenance["RecipeVersion"] == "1.0"
+        assert provenance["GeneratedBy"]["Name"] == "prism-tools"
+
+        expected_hash = hashlib.sha256(survey_tsv.read_bytes()).hexdigest()
+        assert provenance["InputFiles"] == [
+            {
+                "Path": "sub-001/ses-1/survey/sub-001_ses-1_task-test_survey.tsv",
+                "SHA256": expected_hash,
+            }
+        ]
+        assert len(provenance["ParticipantsFiles"]) == 1
+        assert provenance["ParticipantsFiles"][0]["Path"] == "participants.tsv"
 
 
 class TestBiometricsModality:


### PR DESCRIPTION
## Summary
- Real `GeneratedBy.Version` (was hardcoded `"1.0.0"`) in derivative `dataset_description.json`, refreshed on every recipe run while preserving user hand-edits (Name, License, etc.)
- New per-recipe `<recipe_id>_provenance.json` sidecar: input file list + sha256 hashes, participants.tsv/json hashes, recipe id/version, generation timestamp
- DataLad-tracked projects get a scoped `datalad save` after recipe scoring (derivative output + seeded recipe copies + `.bidsignore`) — deliberately `datalad save`, not `datalad run` (see commit message for rationale)

## Test plan
- [x] `pytest tests/test_recipes_output_subfolder.py tests/test_recipes_datalad_save.py -q` — new/extended tests pass
- [x] `pytest tests/ -q` — 2708 passed, 1 pre-existing unrelated failure (confirmed via `git stash` to predate this branch)
- [x] `tests/verify_repo.py --check ruff,mypy` — ruff clean; 3 pre-existing mypy errors, none in touched files
- [x] Manual end-to-end smoke test against a real `datalad create` dataset (not mocked): recipe scoring produces one new commit and a fully clean working tree