### PR TITLE
Phase 3: declarative entity/filename rules (validator + rewriter)

### DIFF
--- a/app/schemas/stable/entities.schema.json
+++ b/app/schemas/stable/entities.schema.json
@@ -1,0 +1,76 @@
+{
+  "version": "1.0.0",
+  "description": "Declarative BIDS/PRISM filename and entity rules: which entities are required/optional per modality, entity ordering for rewrites, and the suffix/extension grammar used to validate filenames. Consumed by src/entity_rules.py; do not hand-edit MODALITY_PATTERNS-style regexes in Python instead of this file.",
+  "entityOrder": [
+    "sub",
+    "ses",
+    "task",
+    "acq",
+    "run",
+    "rec",
+    "dir",
+    "echo",
+    "ce",
+    "part",
+    "space",
+    "desc"
+  ],
+  "defaultRequiredEntities": ["sub", "task"],
+  "aliases": {
+    "physiological": "physio"
+  },
+  "modalities": {
+    "survey": {
+      "kind": "prism",
+      "suffixes": ["survey"],
+      "extensions": ["tsv", "json"],
+      "example": {"task": "panas"}
+    },
+    "biometrics": {
+      "kind": "prism",
+      "suffixes": ["biometrics"],
+      "extensions": ["tsv", "json"]
+    },
+    "environment": {
+      "kind": "prism",
+      "suffixes": ["environment"],
+      "extensions": ["tsv", "tsv.gz", "json"],
+      "requiredEntityValues": {
+        "recording": {"pattern": "[a-zA-Z0-9]+"}
+      }
+    },
+    "events": {
+      "kind": "prism",
+      "suffixes": ["events"],
+      "extensions": ["tsv"]
+    },
+    "physio": {
+      "kind": "prism",
+      "suffixes": ["physio"],
+      "extensions": ["tsv", "tsv.gz", "json", "edf"],
+      "optionalEntityValues": {
+        "recording": {
+          "enum": ["ecg", "cardiac", "puls", "resp", "eda", "ppg", "emg", "temp", "bp", "spo2", "trigger"],
+          "allowOther": true,
+          "otherPattern": "[a-zA-Z0-9]+"
+        }
+      }
+    },
+    "eyetracking": {
+      "kind": "bidsPassthrough",
+      "suffixes": ["eyetrack", "eye", "gaze"],
+      "extensions": ["tsv", "tsv.gz", "json", "edf", "asc"],
+      "optionalEntityValues": {
+        "trackedEye": {
+          "enum": ["left", "right", "both"]
+        }
+      }
+    },
+    "anat": {"kind": "bidsPassthrough"},
+    "func": {"kind": "bidsPassthrough"},
+    "fmap": {"kind": "bidsPassthrough"},
+    "dwi": {"kind": "bidsPassthrough"},
+    "eeg": {"kind": "bidsPassthrough"},
+    "beh": {"kind": "bidsPassthrough"}
+  }
+}

--- a/app/src/fixer.py
+++ b/app/src/fixer.py
@@ -20,10 +20,22 @@ from datetime import date
 from typing import List, Dict, Any, Optional
 from dataclasses import dataclass, field
 from src.constants import DEFAULT_BIDS_VERSION
+from src.entity_rules import load_entity_rules
 from src.validator import (
     BIDS_MODALITIES,
     PRISM_MODALITIES,
     resolve_inherited_sidecar,
+)
+
+# Filename substrings that identify an eyetracking file by suffix, e.g.
+# "_eyetrack"/"_eye"/"_gaze". Sourced from entities.schema.json (via
+# src/entity_rules.py) instead of hardcoded here, so a suffix added there
+# (the entities.schema.json eyetracking suffix list previously had "gaze"
+# with no matching check here - files ending "_gaze.tsv" were silently
+# inferred as "unknown") is automatically picked up by modality inference
+# too.
+_EYETRACKING_NAME_HINTS = tuple(
+    f"_{suffix}" for suffix in load_entity_rules().modalities["eyetracking"].suffixes
 )
 
 
@@ -435,10 +447,8 @@ class DatasetFixer:
             return "biometrics"
         elif "/physio/" in path_lower or "_physio" in name_lower:
             return "physio"
-        elif (
-            "/eyetrack" in path_lower
-            or "_eyetrack" in name_lower
-            or "_eye" in name_lower
+        elif "/eyetrack" in path_lower or any(
+            hint in name_lower for hint in _EYETRACKING_NAME_HINTS
         ):
             return "eyetracking"
         elif (

--- a/app/src/issues.py
+++ b/app/src/issues.py
@@ -329,17 +329,20 @@ def get_fix_hint(code: str, message: str = "") -> str:
             modality_match = re.search(r"modality '([^']+)'", message)
             if modality_match:
                 modality = modality_match.group(1)
-                modality_hints = {
-                    "survey": "Ensure the filename ends with '_survey.tsv' or '_survey.json' (e.g., sub-001_task-panas_survey.tsv)",
-                    "biometrics": "Ensure the filename ends with '_biometrics.tsv' or '_biometrics.json' (e.g., sub-001_task-rest_biometrics.tsv)",
-                    "physio": "Ensure the filename ends with '_physio.<ext>' where <ext> is tsv, tsv.gz, json, or edf (e.g., sub-001_task-rest_recording-ecg_physio.tsv)",
-                    "physiological": "Ensure the filename ends with '_physio.<ext>' where <ext> is tsv, tsv.gz, json, or edf (e.g., sub-001_task-rest_recording-ecg_physio.tsv)",
-                    "eyetracking": "Ensure the filename ends with '_eyetrack.<ext>' or '_eye.<ext>' or '_gaze.<ext>' where <ext> is tsv, tsv.gz, json, edf, or asc (e.g., sub-001_task-rest_trackedEye-left_eyetrack.tsv)",
-                    "events": "Ensure the filename ends with '_events.tsv' (e.g., sub-001_task-rest_events.tsv)",
+                from src.entity_rules import describe_modality_pattern, load_entity_rules
+
+                # Only the modalities with a hand-authored hint historically
+                # get one here; others fall through to the generic message
+                # below (matches the pre-entity_rules.py hardcoded dict).
+                hinted_modalities = {
+                    "survey", "biometrics", "physio", "physiological", "eyetracking", "events",
                 }
-                return modality_hints.get(
-                    modality,
-                    f"Ensure the filename ends with '_{modality}.<ext>' appropriate for this modality",
+                rules = load_entity_rules()
+                rule = rules.modalities.get(modality)
+                if modality in hinted_modalities and rule is not None:
+                    return describe_modality_pattern(rule)
+                return (
+                    f"Ensure the filename ends with '_{modality}.<ext>' appropriate for this modality"
                 )
 
         # Schema validation errors (PRISM301)

--- a/app/src/validator.py
+++ b/app/src/validator.py
@@ -11,6 +11,7 @@ from pathlib import Path
 from datetime import datetime
 from jsonschema import validate, ValidationError
 from src.schema_manager import validate_schema_version, apply_schema_validation_profile
+from src.entity_rules import load_entity_rules
 from src.cross_platform import (
     normalize_path,
     safe_path_join,
@@ -18,33 +19,24 @@ from src.cross_platform import (
     validate_filename_cross_platform,
 )
 
+_ENTITY_RULES = load_entity_rules()
+
 # PRISM-specific modalities that we validate with our schemas
 # Standard BIDS modalities are passed through and should be validated by
 # the optional BIDS validator instead.
-PRISM_MODALITIES = {
-    "survey",
-    "biometrics",
-    "environment",
-    "events",
-    "physio",
-    "physiological",
-}
+# Sourced from app/schemas/stable/entities.schema.json (see src/entity_rules.py)
+# rather than hardcoded here, so adding/changing a modality's suffix grammar
+# only requires a rules-file edit.
+PRISM_MODALITIES = _ENTITY_RULES.prism_modalities
 
 # Standard BIDS modalities - we only do minimal checks (subject/session consistency)
 # Full validation is delegated to the BIDS validator
-BIDS_MODALITIES = {"anat", "func", "fmap", "dwi", "eeg", "beh", "eyetracking"}
+BIDS_MODALITIES = _ENTITY_RULES.bids_modalities
 
 # Modality patterns used for discovery and PRISM checks.
 # Strict pattern enforcement is applied only to PRISM modalities.
 MODALITY_PATTERNS = {
-    # PRISM survey/biometrics must carry explicit suffixes
-    "survey": r".+_survey\.(tsv|json)$",
-    "biometrics": r".+_biometrics\.(tsv|json)$",
-    "environment": r".+_recording-[a-zA-Z0-9]+_environment\.(tsv|tsv\.gz|json)$",
-    "events": r".+_events\.tsv$",
-    "physio": r".+(_recording-(ecg|cardiac|puls|resp|eda|ppg|emg|temp|bp|spo2|trigger|[a-zA-Z0-9]+))?_physio\.(tsv|tsv\.gz|json|edf)$",
-    "physiological": r".+(_recording-(ecg|cardiac|puls|resp|eda|ppg|emg|temp|bp|spo2|trigger|[a-zA-Z0-9]+))?_physio\.(tsv|tsv\.gz|json|edf)$",
-    "eyetracking": r".+(_trackedEye-(left|right|both))?_(eyetrack|eye|gaze)\.(tsv|tsv\.gz|json|edf|asc)$",
+    modality: _ENTITY_RULES.pattern_for(modality) for modality in _ENTITY_RULES.modalities
 }
 
 # BIDS naming patterns

--- a/app/src/validator.py
+++ b/app/src/validator.py
@@ -36,7 +36,9 @@ BIDS_MODALITIES = _ENTITY_RULES.bids_modalities
 # Modality patterns used for discovery and PRISM checks.
 # Strict pattern enforcement is applied only to PRISM modalities.
 MODALITY_PATTERNS = {
-    modality: _ENTITY_RULES.pattern_for(modality) for modality in _ENTITY_RULES.modalities
+    modality: _ENTITY_RULES.pattern_for(modality)
+    for modality, rule in _ENTITY_RULES.modalities.items()
+    if rule.suffixes
 }
 
 # BIDS naming patterns

--- a/src/bids_entity_rewriter.py
+++ b/src/bids_entity_rewriter.py
@@ -5,6 +5,7 @@ from dataclasses import dataclass
 from pathlib import Path
 
 from src.bids_entity_parser import BidsEntityParser
+from src.entity_rules import load_entity_rules
 from src.system_files import filter_system_files
 
 _IGNORED_DIR_NAMES = {
@@ -27,21 +28,11 @@ _TEXT_SUFFIXES = {
 _TEXT_FILENAMES = {".bidsignore"}
 _DOUBLE_SUFFIXES = (".nii.gz", ".tsv.gz")
 _NON_EDITABLE_ENTITIES = {"sub"}
-_ENTITY_ORDER = [
-    "sub",
-    "ses",
-    "task",
-    "acq",
-    "run",
-    "rec",
-    "dir",
-    "echo",
-    "ce",
-    "part",
-    "space",
-    "desc",
-]
-_REQUIRED_ENTITIES = {"sub", "task"}
+# Sourced from app/schemas/stable/entities.schema.json (see src/entity_rules.py)
+# rather than hardcoded here, so adding/reordering an entity only requires a
+# rules-file edit.
+_ENTITY_ORDER = list(load_entity_rules().entity_order)
+_REQUIRED_ENTITIES = set(load_entity_rules().default_required_entities)
 
 
 @dataclass(frozen=True)

--- a/src/entity_rules.py
+++ b/src/entity_rules.py
@@ -1,0 +1,178 @@
+"""Loader/compiler for the declarative entity/filename rules in
+app/schemas/*/entities.json.
+
+This is the single source of truth for per-modality suffix/extension/entity
+grammar. Consumers (validator, fixer, issue hints, entity rewriter) compile
+concrete regexes/strings from it instead of hardcoding their own copies.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from functools import lru_cache
+from pathlib import Path
+
+from src.schema_manager import load_schema
+
+_REPO_ROOT = Path(__file__).resolve().parent.parent
+_DEFAULT_SCHEMA_DIR = str(_REPO_ROOT / "app" / "schemas")
+
+
+@dataclass(frozen=True)
+class EntityValueRule:
+    pattern: str | None = None
+    enum: tuple[str, ...] = ()
+    allow_other: bool = False
+    other_pattern: str | None = None
+
+    @classmethod
+    def from_json(cls, data: dict) -> "EntityValueRule":
+        return cls(
+            pattern=data.get("pattern"),
+            enum=tuple(data.get("enum", ())),
+            allow_other=bool(data.get("allowOther", False)),
+            other_pattern=data.get("otherPattern"),
+        )
+
+    def alternatives(self) -> str:
+        if self.enum:
+            alts = list(self.enum)
+            if self.allow_other and self.other_pattern:
+                alts.append(self.other_pattern)
+            return "|".join(alts)
+        return self.pattern or ""
+
+
+@dataclass(frozen=True)
+class ModalityRule:
+    name: str
+    kind: str
+    suffixes: tuple[str, ...] = ()
+    extensions: tuple[str, ...] = ()
+    required_entity_values: tuple[tuple[str, EntityValueRule], ...] = ()
+    optional_entity_values: tuple[tuple[str, EntityValueRule], ...] = ()
+    example_task: str = "rest"
+
+    @classmethod
+    def from_json(cls, name: str, data: dict) -> "ModalityRule":
+        return cls(
+            name=name,
+            kind=data.get("kind", "prism"),
+            suffixes=tuple(data.get("suffixes", ())),
+            extensions=tuple(data.get("extensions", ())),
+            required_entity_values=tuple(
+                (key, EntityValueRule.from_json(value))
+                for key, value in data.get("requiredEntityValues", {}).items()
+            ),
+            optional_entity_values=tuple(
+                (key, EntityValueRule.from_json(value))
+                for key, value in data.get("optionalEntityValues", {}).items()
+            ),
+            example_task=data.get("example", {}).get("task", "rest"),
+        )
+
+
+@dataclass(frozen=True)
+class EntityRules:
+    entity_order: tuple[str, ...]
+    default_required_entities: frozenset
+    modalities: dict[str, ModalityRule]
+    aliases: dict[str, str]
+
+    @property
+    def prism_modalities(self) -> set[str]:
+        return {name for name, rule in self.modalities.items() if rule.kind == "prism"}
+
+    @property
+    def bids_modalities(self) -> set[str]:
+        return {
+            name for name, rule in self.modalities.items() if rule.kind == "bidsPassthrough"
+        }
+
+    def pattern_for(self, modality: str) -> str:
+        rule = self.modalities.get(modality)
+        if rule is None or not rule.suffixes or not rule.extensions:
+            return r".*"
+        return compile_modality_regex(rule)
+
+
+def compile_modality_regex(rule: ModalityRule) -> str:
+    """Rebuild the MODALITY_PATTERNS-style regex source for a modality rule."""
+    prefix_parts: list[str] = []
+    for key, value_rule in rule.required_entity_values:
+        alt = value_rule.alternatives()
+        prefix_parts.append(f"_{key}-({alt})" if value_rule.enum else f"_{key}-{alt}")
+    for key, value_rule in rule.optional_entity_values:
+        prefix_parts.append(f"(_{key}-({value_rule.alternatives()}))?")
+
+    suffix_part = (
+        rule.suffixes[0] if len(rule.suffixes) == 1 else "(" + "|".join(rule.suffixes) + ")"
+    )
+    escaped_exts = [ext.replace(".", r"\.") for ext in rule.extensions]
+    ext_part = escaped_exts[0] if len(escaped_exts) == 1 else "(" + "|".join(escaped_exts) + ")"
+
+    return rf".+{''.join(prefix_parts)}_{suffix_part}\.{ext_part}$"
+
+
+def _human_join(items: tuple[str, ...]) -> str:
+    parts = list(items)
+    if len(parts) == 1:
+        return parts[0]
+    return ", ".join(parts[:-1]) + ", or " + parts[-1]
+
+
+def describe_modality_pattern(rule: ModalityRule) -> str:
+    """Rebuild the get_fix_hint()-style human-readable hint for a modality rule."""
+    if not rule.suffixes or not rule.extensions:
+        return f"Ensure the filename ends with '_{rule.name}.<ext>' appropriate for this modality"
+
+    entity_values = rule.required_entity_values + rule.optional_entity_values
+    entity_token = ""
+    if entity_values:
+        key, value_rule = entity_values[0]
+        example_value = value_rule.enum[0] if value_rule.enum else "example"
+        entity_token = f"{key}-{example_value}_"
+
+    example_suffix = rule.suffixes[0]
+    example_ext = rule.extensions[0]
+
+    if len(rule.extensions) >= 3:
+        ext_list_str = _human_join(rule.extensions)
+        suffix_clause = " or ".join(f"'_{s}.<ext>'" for s in rule.suffixes)
+        head = f"Ensure the filename ends with {suffix_clause} where <ext> is {ext_list_str}"
+    elif len(rule.extensions) == 2:
+        head = (
+            f"Ensure the filename ends with '_{example_suffix}.{rule.extensions[0]}' "
+            f"or '_{example_suffix}.{rule.extensions[1]}'"
+        )
+    else:
+        head = f"Ensure the filename ends with '_{example_suffix}.{rule.extensions[0]}'"
+
+    example = f"(e.g., sub-001_task-{rule.example_task}_{entity_token}{example_suffix}.{example_ext})"
+    return f"{head} {example}"
+
+
+@lru_cache(maxsize=None)
+def load_entity_rules(schema_dir: str | None = None, version: str = "stable") -> EntityRules:
+    schema = load_schema("entities", schema_dir or _DEFAULT_SCHEMA_DIR, version)
+    if not schema:
+        raise RuntimeError(
+            "Could not load entities.json rules file from "
+            f"{schema_dir or _DEFAULT_SCHEMA_DIR}/{version}."
+        )
+
+    aliases = dict(schema.get("aliases", {}))
+    modalities: dict[str, ModalityRule] = {
+        name: ModalityRule.from_json(name, data)
+        for name, data in schema.get("modalities", {}).items()
+    }
+    for alias_name, target_name in aliases.items():
+        if target_name in modalities:
+            modalities[alias_name] = modalities[target_name]
+
+    return EntityRules(
+        entity_order=tuple(schema.get("entityOrder", ())),
+        default_required_entities=frozenset(schema.get("defaultRequiredEntities", ())),
+        modalities=modalities,
+        aliases=aliases,
+    )

--- a/tests/CLAUDE.md
+++ b/tests/CLAUDE.md
@@ -85,6 +85,9 @@ black . && flake8 .              # Format and lint
 When modifying modalities:
 1. `schemas/` - JSON schema definitions
 2. `src/schema_manager.py` - modalities list
-3. `src/validator.py` - MODALITY_PATTERNS
+3. `app/schemas/stable/entities.schema.json` - suffix/extension/entity grammar
+   per modality (`src/entity_rules.py` compiles this into `validator.py`'s
+   `MODALITY_PATTERNS`/`PRISM_MODALITIES`/`BIDS_MODALITIES` and `issues.py`'s
+   fix hints — don't hand-edit those, edit the rules file instead)
 4. `prism-studio.py` - restricted_names
 5. `templates/index.html` - UI list

--- a/tests/test_entity_rules.py
+++ b/tests/test_entity_rules.py
@@ -88,3 +88,17 @@ def test_pattern_for_unlisted_modality_falls_back_to_catch_all():
 
 def test_load_entity_rules_is_cached():
     assert load_entity_rules() is load_entity_rules()
+
+
+def test_modalities_with_suffixes_matches_original_pattern_dict_keys():
+    """validator.py's MODALITY_PATTERNS must only carry the 7 modalities the
+    hardcoded dict used to have - not every entities.schema.json entry (e.g.
+    bidsPassthrough modalities like anat/func with no suffix grammar of
+    their own). Consumers like app/src/runner.py iterate this dict's keys
+    directly, so an inflated key set would be a real behavior change even
+    though nothing in this repo currently trips over it."""
+    rules = load_entity_rules()
+    modalities_with_suffixes = {
+        name for name, rule in rules.modalities.items() if rule.suffixes
+    }
+    assert modalities_with_suffixes == set(_EXPECTED_PATTERNS.keys())

--- a/tests/test_entity_rules.py
+++ b/tests/test_entity_rules.py
@@ -1,0 +1,90 @@
+"""Regression guard for src/entity_rules.py.
+
+The compiled regex/hint strings must be byte-identical to the hardcoded
+constants they replace in app/src/validator.py and app/src/issues.py, so
+this migration is a verified no-op rather than a "should behave the same"
+hope.
+"""
+
+from __future__ import annotations
+
+from src.entity_rules import (
+    compile_modality_regex,
+    describe_modality_pattern,
+    load_entity_rules,
+)
+
+# Copied verbatim from app/src/validator.py's MODALITY_PATTERNS as it stood
+# before the entities.json migration.
+_EXPECTED_PATTERNS = {
+    "survey": r".+_survey\.(tsv|json)$",
+    "biometrics": r".+_biometrics\.(tsv|json)$",
+    "environment": r".+_recording-[a-zA-Z0-9]+_environment\.(tsv|tsv\.gz|json)$",
+    "events": r".+_events\.tsv$",
+    "physio": r".+(_recording-(ecg|cardiac|puls|resp|eda|ppg|emg|temp|bp|spo2|trigger|[a-zA-Z0-9]+))?_physio\.(tsv|tsv\.gz|json|edf)$",
+    "physiological": r".+(_recording-(ecg|cardiac|puls|resp|eda|ppg|emg|temp|bp|spo2|trigger|[a-zA-Z0-9]+))?_physio\.(tsv|tsv\.gz|json|edf)$",
+    "eyetracking": r".+(_trackedEye-(left|right|both))?_(eyetrack|eye|gaze)\.(tsv|tsv\.gz|json|edf|asc)$",
+}
+
+# Copied verbatim from app/src/issues.py's get_fix_hint() modality_hints dict.
+_EXPECTED_HINTS = {
+    "survey": "Ensure the filename ends with '_survey.tsv' or '_survey.json' (e.g., sub-001_task-panas_survey.tsv)",
+    "biometrics": "Ensure the filename ends with '_biometrics.tsv' or '_biometrics.json' (e.g., sub-001_task-rest_biometrics.tsv)",
+    "physio": "Ensure the filename ends with '_physio.<ext>' where <ext> is tsv, tsv.gz, json, or edf (e.g., sub-001_task-rest_recording-ecg_physio.tsv)",
+    "physiological": "Ensure the filename ends with '_physio.<ext>' where <ext> is tsv, tsv.gz, json, or edf (e.g., sub-001_task-rest_recording-ecg_physio.tsv)",
+    "eyetracking": "Ensure the filename ends with '_eyetrack.<ext>' or '_eye.<ext>' or '_gaze.<ext>' where <ext> is tsv, tsv.gz, json, edf, or asc (e.g., sub-001_task-rest_trackedEye-left_eyetrack.tsv)",
+    "events": "Ensure the filename ends with '_events.tsv' (e.g., sub-001_task-rest_events.tsv)",
+}
+
+_EXPECTED_ENTITY_ORDER = (
+    "sub", "ses", "task", "acq", "run", "rec", "dir", "echo", "ce", "part", "space", "desc",
+)
+_EXPECTED_REQUIRED_ENTITIES = frozenset({"sub", "task"})
+
+
+def test_compiled_regex_matches_hardcoded_patterns():
+    rules = load_entity_rules()
+    for modality, expected in _EXPECTED_PATTERNS.items():
+        rule = rules.modalities[modality]
+        assert compile_modality_regex(rule) == expected, modality
+
+
+def test_describe_modality_pattern_matches_hardcoded_hints():
+    rules = load_entity_rules()
+    for modality, expected in _EXPECTED_HINTS.items():
+        rule = rules.modalities[modality]
+        assert describe_modality_pattern(rule) == expected, modality
+
+
+def test_entity_order_matches_hardcoded_constant():
+    rules = load_entity_rules()
+    assert rules.entity_order == _EXPECTED_ENTITY_ORDER
+
+
+def test_default_required_entities_matches_hardcoded_constant():
+    rules = load_entity_rules()
+    assert rules.default_required_entities == _EXPECTED_REQUIRED_ENTITIES
+
+
+def test_prism_modalities_matches_hardcoded_constant():
+    rules = load_entity_rules()
+    assert rules.prism_modalities == {
+        "survey", "biometrics", "environment", "events", "physio", "physiological",
+    }
+
+
+def test_bids_modalities_matches_hardcoded_constant():
+    rules = load_entity_rules()
+    assert rules.bids_modalities == {
+        "anat", "func", "fmap", "dwi", "eeg", "beh", "eyetracking",
+    }
+
+
+def test_pattern_for_unlisted_modality_falls_back_to_catch_all():
+    rules = load_entity_rules()
+    assert rules.pattern_for("anat") == r".*"
+    assert rules.pattern_for("does-not-exist") == r".*"
+
+
+def test_load_entity_rules_is_cached():
+    assert load_entity_rules() is load_entity_rules()

--- a/tests/test_fixer_infer_modality.py
+++ b/tests/test_fixer_infer_modality.py
@@ -1,0 +1,54 @@
+"""Tests for DatasetFixer._infer_modality(), in particular the eyetracking
+suffix hints, which are now sourced from entities.schema.json (via
+src/entity_rules.py) instead of a hardcoded, incomplete substring list -
+the previous list checked "_eyetrack"/"_eye" but not "_gaze", even though
+"_gaze" is a valid eyetracking suffix in the validator's own grammar.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from src.fixer import DatasetFixer
+
+
+def _fixer(tmp_path: Path) -> DatasetFixer:
+    return DatasetFixer(str(tmp_path), dry_run=True)
+
+
+def test_infers_eyetracking_from_gaze_suffix(tmp_path: Path) -> None:
+    fixer = _fixer(tmp_path)
+    filename = "sub-001_task-rest_gaze.tsv"
+    assert fixer._infer_modality(filename, filename) == "eyetracking"
+
+
+def test_infers_eyetracking_from_eyetrack_suffix(tmp_path: Path) -> None:
+    fixer = _fixer(tmp_path)
+    filename = "sub-001_task-rest_eyetrack.tsv"
+    assert fixer._infer_modality(filename, filename) == "eyetracking"
+
+
+def test_infers_eyetracking_from_eye_suffix(tmp_path: Path) -> None:
+    fixer = _fixer(tmp_path)
+    filename = "sub-001_task-rest_eye.tsv"
+    assert fixer._infer_modality(filename, filename) == "eyetracking"
+
+
+def test_infers_eyetracking_from_directory(tmp_path: Path) -> None:
+    fixer = _fixer(tmp_path)
+    file_path = "sub-001/ses-1/eyetracking/sub-001_ses-1_task-rest_gaze.tsv"
+    filename = "sub-001_ses-1_task-rest_gaze.tsv"
+    assert fixer._infer_modality(file_path, filename) == "eyetracking"
+
+
+def test_infers_events_survey_biometrics_physio_unchanged(tmp_path: Path) -> None:
+    fixer = _fixer(tmp_path)
+    assert fixer._infer_modality("x", "sub-001_task-rest_events.tsv") == "events"
+    assert fixer._infer_modality("x", "sub-001_survey-panas.tsv") == "survey"
+    assert fixer._infer_modality("x", "sub-001_biometrics-hr.tsv") == "biometrics"
+    assert fixer._infer_modality("x", "sub-001_task-rest_physio.tsv") == "physio"
+
+
+def test_infers_unknown_for_unrecognized_file(tmp_path: Path) -> None:
+    fixer = _fixer(tmp_path)
+    assert fixer._infer_modality("x", "notes.txt") == "unknown"


### PR DESCRIPTION
## Summary
- First incremental PR for ROADMAP.md Phase 3 (v1.19): moves `validator.py`'s `PRISM_MODALITIES`/`BIDS_MODALITIES`/`MODALITY_PATTERNS` and `bids_entity_rewriter.py`'s entity-order/required-entity constants into a new `app/schemas/stable/entities.schema.json`, compiled via new `src/entity_rules.py`
- `issues.py`'s fix-hint text now derives from the same compiled rules instead of an independent hardcoded copy, so hint text can't drift from what the validator actually enforces
- Pure refactor: `compile_modality_regex()`/`describe_modality_pattern()` are verified byte-identical to the previous hardcoded regex/hint strings via `tests/test_entity_rules.py`, before any consumer was touched
- `MODALITY_PATTERNS` is restricted to modalities that actually define suffixes (7 keys), matching the original dict exactly - the first pass derived it from every `entities.schema.json` entry (13 keys, including bare `bidsPassthrough` modalities like `anat`/`func`), which would have been a real behavior change for `runner.py` (imports `MODALITY_PATTERNS.keys()` directly) if not for an incidental overlap with `BIDS_MODALITIES`. Locked in with a regression test instead of relying on that overlap.
- `fixer.py::_infer_modality()`'s eyetracking suffix hints now come from the same rules file too, closing a real pre-existing gap: it checked `_eyetrack`/`_eye` but not `_gaze`, even though `gaze` is a valid eyetracking suffix in the validator's own grammar - a well-formed `sub-001_task-rest_gaze.tsv` was silently inferred as `unknown`. Directory-based checks and the legacy `_survey-`/`_biometrics-` hyphen heuristics elsewhere in that function are untouched (different concern, not part of the suffix grammar).

## Scope
Deliberately scoped to the read path (validation, hints, entity rewriting, modality inference), not the full inventory of hardcoded modality/entity lists across the codebase (filename construction in converters, project scaffolding, `.bidsignore` generation, UI blueprint guards). Those are called out as explicit follow-up in the roadmap, not silently dropped - `bids_integration.py`'s `.bidsignore` generation in particular was left alone given the DataLad text-file policy in `CLAUDE.md`.

Also updated `tests/CLAUDE.md`'s "Schema Updates Checklist" so step 3 points at the new rules file instead of `validator.py`.

## Test plan
- [x] `pytest tests/test_entity_rules.py tests/test_fixer_infer_modality.py -q` - regex/hint-compilation regression guard (byte-identical to prior hardcoded constants) plus new eyetracking-inference coverage
- [x] `pytest tests/ -q` - 2717 passed, 1 pre-existing unrelated failure (confirmed via `git stash` against clean `main`)
- [x] `tests/verify_repo.py --check ruff,mypy` - ruff clean; mypy clean on all touched files (3 pre-existing errors elsewhere, unrelated)
- [x] CI green on macOS/Ubuntu/Windows pytest jobs plus coverage/docs/build checks (re-running after the latest two pushes)

🤖 Generated with [Claude Code](https://claude.com/claude-code)