### PR TITLE
Phase 3 follow-up: declarative entity rules for the write path

### DIFF
--- a/app/src/cli/commands/convert.py
+++ b/app/src/cli/commands/convert.py
@@ -20,6 +20,7 @@ from src.converters.wide_to_long import (
     resolve_wide_to_long_id_uniqueness,
 )
 from src.cross_platform import normalize_path
+from src.entity_rules import load_entity_rules
 
 
 def sanitize_id(id_str):
@@ -42,16 +43,21 @@ def sanitize_id(id_str):
 
 def _normalize_physio_suffix(raw_suffix: str | None) -> str:
     """Normalize CLI physio suffixes to canonical recording-<label>_physio."""
+    rules = load_entity_rules()
+    physio_suffix = rules.primary_suffix("physio")
+    recording_rule = dict(rules.modalities["physio"].optional_entity_values)["recording"]
+    default_recording = recording_rule.enum[0]
+
     suffix = str(raw_suffix or "").strip()
     if not suffix:
-        return "recording-ecg_physio"
-    if suffix == "physio":
-        return "recording-ecg_physio"
+        return f"recording-{default_recording}_{physio_suffix}"
+    if suffix == physio_suffix:
+        return f"recording-{default_recording}_{physio_suffix}"
     if suffix.startswith("recording-"):
-        return suffix if suffix.endswith("_physio") else f"{suffix}_physio"
-    if suffix.endswith("_physio"):
+        return suffix if suffix.endswith(f"_{physio_suffix}") else f"{suffix}_{physio_suffix}"
+    if suffix.endswith(f"_{physio_suffix}"):
         return suffix
-    return f"recording-{suffix}_physio"
+    return f"recording-{suffix}_{physio_suffix}"
 
 
 def get_json_hash(json_path):

--- a/app/src/cli/parser.py
+++ b/app/src/cli/parser.py
@@ -5,6 +5,8 @@ from __future__ import annotations
 import argparse
 from pathlib import Path
 
+from src.entity_rules import load_entity_rules
+
 
 def build_parser() -> argparse.ArgumentParser:
     """Create a base parser for prism_tools."""
@@ -27,6 +29,12 @@ def build_prism_tools_parsers(
         dest="modality", help="Modality to convert"
     )
 
+    _rules = load_entity_rules()
+    _physio_suffix = _rules.primary_suffix("physio")
+    _default_recording = dict(_rules.modalities["physio"].optional_entity_values)[
+        "recording"
+    ].enum[0]
+
     parser_physio = convert_subparsers.add_parser(
         "physio", help="Convert physiological data (Varioport)"
     )
@@ -43,8 +51,11 @@ def build_prism_tools_parsers(
     )
     parser_physio.add_argument(
         "--suffix",
-        default="physio",
-        help="Output suffix. 'physio' is normalized to 'recording-ecg_physio' for BIDS-like naming.",
+        default=_physio_suffix,
+        help=(
+            f"Output suffix. '{_physio_suffix}' is normalized to "
+            f"'recording-{_default_recording}_{_physio_suffix}' for BIDS-like naming."
+        ),
     )
     parser_physio.add_argument(
         "--sampling-rate", type=float, help="Override sampling rate (e.g. 256)"

--- a/app/src/converters/survey_core.py
+++ b/app/src/converters/survey_core.py
@@ -25,10 +25,16 @@ try:
 except ImportError:
     from src.survey_scale_inference import apply_implicit_numeric_level_ranges
 
+from src.entity_rules import load_entity_rules
+
 try:
     import pandas as pd
 except ImportError:
     pd = None
+
+# Sourced from app/schemas/stable/entities.schema.json (see src/entity_rules.py)
+# rather than hardcoded here.
+_SURVEY_SUFFIX = load_entity_rules().primary_suffix("survey")
 
 
 # =============================================================================
@@ -129,7 +135,7 @@ def _build_bids_survey_filename(
     normalized_run = _normalize_run_entity(run)
     if normalized_run is not None:
         parts.append(normalized_run)
-    parts.append("survey")  # Add suffix without extension
+    parts.append(_SURVEY_SUFFIX)  # Add suffix without extension
     return "_".join(parts) + f".{extension}"
 
 

--- a/src/converters/biometrics.py
+++ b/src/converters/biometrics.py
@@ -23,9 +23,14 @@ from src.converters.file_reader import (
     infer_tabular_kind as _infer_tabular_kind,
     read_tabular_file as _read_tabular_file,
 )
+from src.entity_rules import load_entity_rules
 from src.subject_id_matching import build_subject_id_matcher
 from src.utils.io import read_json as _read_json, write_json as _write_json
 from src.utils.naming import norm_key as _norm_key
+
+# Sourced from app/schemas/stable/entities.schema.json (see src/entity_rules.py)
+# rather than hardcoded here.
+_BIOMETRICS_SUFFIX = load_entity_rules().primary_suffix("biometrics")
 
 _NON_ITEM_TOPLEVEL_KEYS: set[str] = {
     "Technical",
@@ -370,7 +375,7 @@ def convert_biometrics_table_to_prism_dataset(
 
     # Write inherited sidecars (dataset-level)
     for task, template in task_to_template.items():
-        sidecar_path = output_root / f"task-{task}_biometrics.json"
+        sidecar_path = output_root / f"task-{task}_{_BIOMETRICS_SUFFIX}.json"
         _write_json(sidecar_path, template)
 
     # Write per-row TSVs
@@ -417,7 +422,7 @@ def convert_biometrics_table_to_prism_dataset(
 
             modality_dir = output_root / sub_id / ses_id / "biometrics"
             modality_dir.mkdir(parents=True, exist_ok=True)
-            stem = f"{sub_id}_{ses_id}_task-{task}_biometrics"
+            stem = f"{sub_id}_{ses_id}_task-{task}_{_BIOMETRICS_SUFFIX}"
             out_tsv = modality_dir / f"{stem}.tsv"
             pd.DataFrame([values], columns=items).to_csv(out_tsv, sep="\t", index=False)
 

--- a/src/entity_rules.py
+++ b/src/entity_rules.py
@@ -95,6 +95,17 @@ class EntityRules:
             return r".*"
         return compile_modality_regex(rule)
 
+    def primary_suffix(self, modality: str) -> str:
+        """The canonical suffix to use when *writing* a file for this
+        modality (the first entry in its suffixes list). Modalities with
+        multiple accepted suffixes (e.g. eyetracking's eyetrack/eye/gaze)
+        are for validation only here - writers always emit the primary
+        one."""
+        rule = self.modalities.get(modality)
+        if rule is None or not rule.suffixes:
+            raise KeyError(f"No suffix defined for modality '{modality}'")
+        return rule.suffixes[0]
+
 
 def compile_modality_regex(rule: ModalityRule) -> str:
     """Rebuild the MODALITY_PATTERNS-style regex source for a modality rule."""

--- a/tests/test_entity_rules_write_path.py
+++ b/tests/test_entity_rules_write_path.py
@@ -1,0 +1,99 @@
+"""Regression guard for the write-path (filename construction) migration
+onto src/entity_rules.py.
+
+Biometrics filename construction already has exact-filename coverage in
+tests/test_biometrics_cli.py (e.g. "sub-01_ses-1_task-grip_biometrics.tsv"),
+so it isn't duplicated here.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from src.entity_rules import load_entity_rules
+
+
+def test_primary_suffix_for_known_modalities():
+    rules = load_entity_rules()
+    assert rules.primary_suffix("survey") == "survey"
+    assert rules.primary_suffix("biometrics") == "biometrics"
+    assert rules.primary_suffix("physio") == "physio"
+
+
+def test_primary_suffix_prefers_first_of_multiple_suffixes():
+    rules = load_entity_rules()
+    # eyetracking has three accepted suffixes for validation; writers should
+    # get the primary one.
+    assert rules.primary_suffix("eyetracking") == "eyetrack"
+
+
+def test_primary_suffix_raises_for_unknown_modality():
+    rules = load_entity_rules()
+    with pytest.raises(KeyError):
+        rules.primary_suffix("does-not-exist")
+
+
+def test_primary_suffix_raises_for_suffixless_modality():
+    rules = load_entity_rules()
+    with pytest.raises(KeyError):
+        rules.primary_suffix("anat")
+
+
+class TestBuildBidsSurveyFilename:
+    def _build(self, **kwargs):
+        from app.src.converters.survey_core import _build_bids_survey_filename
+
+        return _build_bids_survey_filename(**kwargs)
+
+    def test_minimal(self):
+        assert (
+            self._build(sub_id="sub-01", ses_id="ses-1", task="panas")
+            == "sub-01_ses-1_task-panas_survey.tsv"
+        )
+
+    def test_with_acq_and_run(self):
+        assert (
+            self._build(
+                sub_id="sub-01", ses_id="ses-1", task="panas", acq="a", run=2
+            )
+            == "sub-01_ses-1_task-panas_acq-a_run-2_survey.tsv"
+        )
+
+    def test_json_extension(self):
+        assert (
+            self._build(
+                sub_id="sub-01", ses_id="ses-1", task="panas", extension="json"
+            )
+            == "sub-01_ses-1_task-panas_survey.json"
+        )
+
+
+class TestNormalizePhysioSuffix:
+    def _normalize(self, raw):
+        from app.src.cli.commands.convert import _normalize_physio_suffix
+
+        return _normalize_physio_suffix(raw)
+
+    def test_none_defaults_to_ecg(self):
+        assert self._normalize(None) == "recording-ecg_physio"
+
+    def test_empty_string_defaults_to_ecg(self):
+        assert self._normalize("") == "recording-ecg_physio"
+
+    def test_bare_physio_defaults_to_ecg(self):
+        assert self._normalize("physio") == "recording-ecg_physio"
+
+    def test_recording_prefix_without_physio_suffix(self):
+        assert self._normalize("recording-eda") == "recording-eda_physio"
+
+    def test_recording_prefix_with_physio_suffix_unchanged(self):
+        assert self._normalize("recording-eda_physio") == "recording-eda_physio"
+
+    def test_bare_label_gets_recording_prefix(self):
+        assert self._normalize("eda") == "recording-eda_physio"
+
+    def test_bare_label_with_physio_suffix_returned_unchanged(self):
+        # Pre-existing quirk, unchanged by this migration: anything already
+        # ending in "_physio" short-circuits before the "add recording-
+        # prefix" branch, even without a "recording-" prefix of its own.
+        assert self._normalize("eda_physio") == "eda_physio"


### PR DESCRIPTION
## Summary
Follow-up to #81 (which covered the read path: validation, hints, rewriting, modality inference). This PR migrates the *write* path — filename construction in the converters:

- `EntityRules.primary_suffix(modality)` (new, `src/entity_rules.py`): the canonical suffix to emit when writing a file for a modality (first entry in its `suffixes` list). Modalities with multiple accepted suffixes (eyetracking's `eyetrack`/`eye`/`gaze`) are for validation only there - writers always emit the primary one.
- `app/src/converters/survey_core.py::_build_bids_survey_filename()` - suffix literal `"survey"` now comes from `primary_suffix("survey")`.
- `src/converters/biometrics.py` - sidecar (`task-<x>_biometrics.json`) and per-row TSV stem now use `primary_suffix("biometrics")` instead of a hardcoded literal.
- `app/src/cli/commands/convert.py::_normalize_physio_suffix()` - both the `"physio"` suffix and the default `"ecg"` recording label now come from `entities.schema.json` instead of two more independent hardcoded copies.
- `app/src/cli/parser.py`'s `--suffix` help text is generated from the same two values, so the CLI's own `--help` output can't drift from what the function does.

Pure refactor, not a feature: no new entity support was added (e.g. biometrics still doesn't support acq/run entities - that's an intentional non-goal, not an oversight).

## Test plan
- [x] `pytest tests/test_entity_rules_write_path.py -q` - new regression tests for `primary_suffix()`, the survey filename builder, and the physio suffix normalizer (none had direct unit tests before)
- [x] `pytest tests/ -q` - 2737 passed, 1 pre-existing unrelated failure (same one noted in #80/#81)
- [x] `tests/verify_repo.py --check ruff,mypy` - ruff clean; mypy clean on all touched files (3 pre-existing errors elsewhere, unrelated)
- [x] Biometrics filename regression already covered by `test_biometrics_cli.py`'s exact-filename assertions (e.g. `sub-01_ses-1_task-grip_biometrics.tsv`) - not duplicated here

🤖 Generated with [Claude Code](https://claude.com/claude-code)