### PR TITLE
Centralize SUPPORTED_MODALITIES ("survey","biometrics") constant

### DIFF
--- a/app/src/constants.py
+++ b/app/src/constants.py
@@ -6,3 +6,10 @@ Single source of truth for values that must remain consistent across modules.
 # Default BIDS specification version used when creating or fixing dataset_description.json.
 # Update here only — all modules should import from this module.
 DEFAULT_BIDS_VERSION = "1.10.1"
+
+# Modalities the Template Editor / Recipe Builder features support. This is
+# a feature-scope concept, not filename grammar (see src/entity_rules.py for
+# that) - it happens to share values with some entity_rules modalities today
+# but is a separate axis (e.g. adding a new BIDS suffix to entities.schema.json
+# should not automatically expand recipe/template support to it).
+SUPPORTED_MODALITIES: tuple[str, ...] = ("survey", "biometrics")

--- a/app/src/recipe_validation.py
+++ b/app/src/recipe_validation.py
@@ -13,6 +13,8 @@ from __future__ import annotations
 import re
 from typing import Any
 
+from src.constants import SUPPORTED_MODALITIES
+
 ALLOWED_DERIVED_METHODS = {"max", "min", "mean", "avg", "sum", "map", "formula"}
 ALLOWED_SCORE_METHODS = {"sum", "mean", "formula", "map"}
 ALLOWED_MISSING = {"ignore", "require_all", "all", "strict"}
@@ -156,7 +158,7 @@ def validate_recipe(
         return [prefix + "recipe must be a JSON object"]
 
     kind = str(recipe.get("Kind", "")).strip().lower()
-    if kind not in {"survey", "biometrics"}:
+    if kind not in SUPPORTED_MODALITIES:
         errors.append(prefix + "Kind must be 'survey' or 'biometrics'")
 
     if not _is_nonempty_str(recipe.get("RecipeVersion")):

--- a/app/src/web/blueprints/tools_library_handlers.py
+++ b/app/src/web/blueprints/tools_library_handlers.py
@@ -3,6 +3,8 @@ from pathlib import Path
 
 from flask import current_app, jsonify, request, session
 
+from src.constants import SUPPORTED_MODALITIES
+
 from .conversion_utils import resolve_existing_project_root
 
 
@@ -50,7 +52,7 @@ def handle_list_library_files_merged(extract_template_info, global_survey_librar
                     )
                 break
 
-        for folder in ["survey", "biometrics"]:
+        for folder in SUPPORTED_MODALITIES:
             folder_path = lib_p / folder
             if folder_path.exists() and folder_path.is_dir():
                 for filepath in sorted(folder_path.glob("*.json")):
@@ -173,7 +175,7 @@ def handle_list_library_files(extract_template_info):
                 extract_template_info(participants_path, "participants.json")
             )
 
-        for folder in ["survey", "biometrics"]:
+        for folder in SUPPORTED_MODALITIES:
             folder_path = os.path.join(library_path, folder)
             if os.path.exists(folder_path) and os.path.isdir(folder_path):
                 for filename in os.listdir(folder_path):

--- a/app/src/web/blueprints/tools_pages_handlers.py
+++ b/app/src/web/blueprints/tools_pages_handlers.py
@@ -3,6 +3,8 @@ from pathlib import Path
 
 from flask import jsonify, render_template
 
+from src.constants import SUPPORTED_MODALITIES
+
 from .tools_helpers import _default_library_root_for_templates, _global_recipes_root
 
 
@@ -53,7 +55,7 @@ def _detect_available_recipe_modalities(project_root: Path) -> tuple[list[dict],
     }
 
     available: list[dict] = []
-    for modality in ("survey", "biometrics"):
+    for modality in SUPPORTED_MODALITIES:
         if _has_data(modality) and _has_recipes(modality):
             available.append({"value": modality, "label": modality_labels[modality]})
 

--- a/app/src/web/blueprints/tools_recipe_builder_handlers.py
+++ b/app/src/web/blueprints/tools_recipe_builder_handlers.py
@@ -12,6 +12,7 @@ from typing import Any
 
 from flask import current_app, jsonify
 
+from src.constants import SUPPORTED_MODALITIES as _SUPPORTED_MODALITIES
 from src.recipe_validation import validate_recipe
 from src.survey_scale_inference import (
     apply_implicit_numeric_level_ranges,
@@ -45,8 +46,6 @@ _RESERVED_KEYS = {
     "Normative",
     "Questions",
 }
-
-_SUPPORTED_MODALITIES = {"survey", "biometrics"}
 
 # ---------------------------------------------------------------------------
 # Helpers

--- a/app/src/web/blueprints/tools_template_editor_blueprint.py
+++ b/app/src/web/blueprints/tools_template_editor_blueprint.py
@@ -14,6 +14,7 @@ from flask import (
 )
 
 from src.config import load_config
+from src.constants import SUPPORTED_MODALITIES
 from src.converters.survey_io import normalize_paper_software_platform
 from src.survey_scale_inference import apply_implicit_numeric_level_ranges
 from src.utils.io import dump_json_text
@@ -236,7 +237,7 @@ def api_template_editor_list_merged():
     """List templates from both global and project libraries with source indicators."""
     modality = (request.args.get("modality") or "").strip().lower()
     schema_version = (request.args.get("schema_version") or "stable").strip()
-    if modality not in {"survey", "biometrics"}:
+    if modality not in SUPPORTED_MODALITIES:
         return jsonify({"error": "Invalid modality"}), 400
 
     requested_project_path = request.args.get("project_path")
@@ -369,7 +370,7 @@ def api_template_editor_list_merged():
 def api_template_editor_new():
     modality = (request.args.get("modality") or "").strip().lower()
     schema_version = (request.args.get("schema_version") or "stable").strip()
-    if modality not in {"survey", "biometrics"}:
+    if modality not in SUPPORTED_MODALITIES:
         return jsonify({"error": "Invalid modality"}), 400
 
     try:
@@ -390,7 +391,7 @@ def api_template_editor_load():
     filename = (request.args.get("filename") or "").strip()
     library_path = (request.args.get("library_path") or "").strip() or None
     absolute_path = (request.args.get("absolute_path") or "").strip() or None
-    if modality not in {"survey", "biometrics"}:
+    if modality not in SUPPORTED_MODALITIES:
         return jsonify({"error": "Invalid modality"}), 400
     if not filename or "/" in filename or "\\" in filename:
         return jsonify({"error": "Invalid filename"}), 400
@@ -435,7 +436,7 @@ def api_template_editor_validate():
     template = payload.get("template")
     is_global = bool(payload.get("is_global", False))
 
-    if modality not in {"survey", "biometrics"}:
+    if modality not in SUPPORTED_MODALITIES:
         return jsonify({"error": "Invalid modality"}), 400
     if not isinstance(template, dict):
         return jsonify({"error": "Template must be a JSON object"}), 400
@@ -476,7 +477,7 @@ def api_template_editor_validate():
 def api_template_editor_schema():
     modality = (request.args.get("modality") or "").strip().lower()
     schema_version = (request.args.get("schema_version") or "stable").strip()
-    if modality not in {"survey", "biometrics"}:
+    if modality not in SUPPORTED_MODALITIES:
         return jsonify({"error": "Invalid modality"}), 400
 
     try:
@@ -501,7 +502,7 @@ def api_template_editor_download():
         return jsonify({"error": "Template must be a JSON object"}), 400
 
     template = _strip_template_editor_internal_keys(template)
-    if modality in {"survey", "biometrics"}:
+    if modality in SUPPORTED_MODALITIES:
         template = _normalize_template_for_validation(
             modality=modality, template=template
         )
@@ -575,7 +576,7 @@ def api_template_editor_save():
     is_global = bool(payload.get("is_global", False))
     allow_overwrite = bool(payload.get("allow_overwrite", False))
 
-    if modality not in {"survey", "biometrics"}:
+    if modality not in SUPPORTED_MODALITIES:
         return jsonify({"error": "Invalid modality"}), 400
     if not filename or "/" in filename or "\\" in filename:
         return jsonify({"error": "Invalid filename"}), 400
@@ -637,7 +638,7 @@ def api_template_editor_delete():
     modality = (payload.get("modality") or "").strip().lower()
     filename = (payload.get("filename") or "").strip()
 
-    if modality not in {"survey", "biometrics"}:
+    if modality not in SUPPORTED_MODALITIES:
         return jsonify({"error": "Invalid modality"}), 400
     if not filename or "/" in filename or "\\" in filename:
         return jsonify({"error": "Invalid filename"}), 400


### PR DESCRIPTION
## Summary
Bonus cleanup identified while closing out Phase 3 (#83), but a separate, unrelated concept from `src/entity_rules.py`'s filename/entity grammar work: the Template Editor / Recipe Builder features' supported-modality pair (`"survey"`, `"biometrics"`) was hardcoded independently as a set/list/tuple literal in 5 files, 9+ call sites:

- `app/src/recipe_validation.py:159`
- `app/src/web/blueprints/tools_recipe_builder_handlers.py:50` (module constant, ~4 call sites)
- `app/src/web/blueprints/tools_template_editor_blueprint.py` (8 inline literals)
- `app/src/web/blueprints/tools_library_handlers.py` (2 sites)
- `app/src/web/blueprints/tools_pages_handlers.py` (1 site)

Moved to `app/src/constants.py` (already the designated home for cross-module constants) as `SUPPORTED_MODALITIES: tuple[str, ...] = ("survey", "biometrics")`.

Pure refactor - every call site keeps its exact existing semantics (not-in/in checks, for-loop order). No behavior change.

## Explicitly out of scope
`project_manager.py`, `bids_integration.py`, `config.py`, `cli/parser.py`, `validator.py`, `scripts/setup/configure_global_library.py` also hardcode this same pair or a related one, but are deliberately left untouched:
- `project_manager.py` / `bids_integration.py` are project-scaffolding/`.bidsignore`-adjacent - real risk given the DataLad text-file policy in `CLAUDE.md`.
- `validator.py`'s own `{"survey","biometrics"}` is a different concept (strict/ERROR vs lenient/WARNING pattern-mismatch severity) that only coincidentally shares today's value - coupling it to the recipe/template constant would wire together unrelated domains.

## Test plan
- [x] `pytest tests/ -q -k "recipe or template_editor or library"` - 445 passed (targeted)
- [x] `pytest tests/ -q` - 2737 passed, 1 pre-existing unrelated failure (same one noted in #80/#81/#82)
- [x] `tests/verify_repo.py --check ruff,mypy` - ruff clean; mypy clean on all touched files (3 pre-existing errors elsewhere, unrelated)

🤖 Generated with [Claude Code](https://claude.com/claude-code)