### PR TITLE
Migrate project scaffolding / .bidsignore modality lists onto entity_rules

### DIFF
--- a/app/src/bids_integration.py
+++ b/app/src/bids_integration.py
@@ -5,6 +5,8 @@ Handles compatibility with standard BIDS tools and apps.
 
 import os
 
+from src.entity_rules import load_entity_rules
+
 # Standard BIDS modalities (folders)
 # Based on BIDS Specification v1.9.0
 STANDARD_BIDS_FOLDERS = {
@@ -98,17 +100,10 @@ def check_and_update_bidsignore(dataset_root, supported_modalities):
     ]
 
     # Always ensure we include these common PRISM/non-BIDS folders just in case
-    # they are not in the current supported_modalities list
-    prism_folders = {
-        "physiological",
-        "physio",
-        "survey",
-        "biometrics",
-        "environment",
-        "eeg",
-        "metadata",
-        "events",
-    }
+    # they are not in the current supported_modalities list. Sourced from
+    # app/schemas/stable/entities.schema.json (see src/entity_rules.py)
+    # rather than hardcoded here.
+    prism_folders = set(load_entity_rules().prism_modalities)
     for pf in prism_folders:
         if pf not in STANDARD_BIDS_FOLDERS and pf not in non_standard:
             non_standard.append(pf)

--- a/app/src/project_manager.py
+++ b/app/src/project_manager.py
@@ -46,6 +46,7 @@ from src.project_export_helpers import (
 )
 from src.constants import DEFAULT_BIDS_VERSION
 from src.cross_platform import CrossPlatformFile, describe_case_insensitive_id_collisions
+from src.entity_rules import load_entity_rules
 from src.issues import get_fix_hint, infer_code_from_message
 from src.schema_manager import load_schema
 from src.readme_generator import ReadmeGenerator
@@ -53,15 +54,9 @@ from src.project_icons import choose_random_project_icon, normalize_project_icon
 from src.system_files import filter_system_files
 from jsonschema import Draft7Validator
 
-# Available PRISM modalities
-PRISM_MODALITIES = [
-    "survey",
-    "biometrics",
-    "environment",
-    "physio",
-    "eyetracking",
-    "events",
-]
+# Available PRISM modalities. Sourced from app/schemas/stable/entities.schema.json
+# (see src/entity_rules.py) rather than hardcoded here.
+PRISM_MODALITIES = load_entity_rules().project_modalities
 
 # Modalities that remain available in PRISM tooling but are validated as BIDS
 # pass-through instead of PRISM-specific extensions.

--- a/src/entity_rules.py
+++ b/src/entity_rules.py
@@ -89,6 +89,20 @@ class EntityRules:
             name for name, rule in self.modalities.items() if rule.kind == "bidsPassthrough"
         }
 
+    @property
+    def project_modalities(self) -> list[str]:
+        """Modality identities with their own filename-suffix grammar (i.e.
+        excludes alias names like "physiological" and pure-BIDS-passthrough
+        entries with no PRISM suffix data like anat/func). This is the set
+        PRISM offers/manages a folder for at the project level - it includes
+        eyetracking, which has suffix data even though it's validated as
+        BIDS-passthrough (see bids_modalities)."""
+        return [
+            name
+            for name, rule in self.modalities.items()
+            if rule.suffixes and name not in self.aliases
+        ]
+
     def pattern_for(self, modality: str) -> str:
         rule = self.modalities.get(modality)
         if rule is None or not rule.suffixes or not rule.extensions:

--- a/tests/test_bids_integration.py
+++ b/tests/test_bids_integration.py
@@ -56,3 +56,35 @@ def test_check_and_update_bidsignore_keeps_eyetracking_visible_to_bids() -> None
         assert "**/eyetracking/" not in content
         assert "*_eyetrack.*" not in content
         assert "task-*_eyetrack.json" not in content
+
+
+def test_check_and_update_bidsignore_adds_all_prism_modality_folders() -> None:
+    """prism_folders is now derived from src/entity_rules.py's
+    prism_modalities (survey, biometrics, environment, physio,
+    physiological, events) instead of a hardcoded 8-item set - confirms the
+    6 real entries still produce ignore-rules regardless of what's passed
+    in as supported_modalities."""
+    with tempfile.TemporaryDirectory() as tmp:
+        dataset_root = Path(tmp)
+
+        check_and_update_bidsignore(str(dataset_root), [])
+
+        content = (dataset_root / ".bidsignore").read_text(encoding="utf-8")
+        for folder in ("survey", "biometrics", "environment", "physio", "physiological", "events"):
+            assert f"{folder}/" in content, folder
+
+
+def test_check_and_update_bidsignore_never_mentions_dead_eeg_or_metadata() -> None:
+    """The old prism_folders set had "eeg" (dead - already in
+    STANDARD_BIDS_FOLDERS, so it never survived the filter) and
+    "metadata" (unreferenced anywhere else in the codebase) entries.
+    Neither should ever produce a bidsignore line, before or after
+    removing them from the now entity_rules-derived set."""
+    with tempfile.TemporaryDirectory() as tmp:
+        dataset_root = Path(tmp)
+
+        check_and_update_bidsignore(str(dataset_root), [])
+
+        content = (dataset_root / ".bidsignore").read_text(encoding="utf-8")
+        assert "eeg/" not in content
+        assert "metadata/" not in content

--- a/tests/test_entity_rules.py
+++ b/tests/test_entity_rules.py
@@ -102,3 +102,28 @@ def test_modalities_with_suffixes_matches_original_pattern_dict_keys():
         name for name, rule in rules.modalities.items() if rule.suffixes
     }
     assert modalities_with_suffixes == set(_EXPECTED_PATTERNS.keys())
+
+
+def test_project_modalities_matches_project_manager_hardcoded_list():
+    """project_manager.py's PRISM_MODALITIES used to hardcode exactly these
+    6 names (order differs, which is harmless - nothing depends on it)."""
+    rules = load_entity_rules()
+    assert set(rules.project_modalities) == {
+        "survey", "biometrics", "environment", "physio", "eyetracking", "events",
+    }
+
+
+def test_project_modalities_excludes_alias_and_bare_bids_passthrough():
+    rules = load_entity_rules()
+    assert "physiological" not in rules.project_modalities
+    assert "anat" not in rules.project_modalities
+    assert "func" not in rules.project_modalities
+
+
+def test_prism_modalities_matches_bids_integration_prism_folders_intent():
+    """bids_integration.py's prism_folders used to hardcode these 6 names
+    (plus dead "eeg" and vestigial "metadata" entries, since removed)."""
+    rules = load_entity_rules()
+    assert rules.prism_modalities == {
+        "survey", "biometrics", "environment", "physio", "physiological", "events",
+    }

--- a/tests/test_project_manager_modalities.py
+++ b/tests/test_project_manager_modalities.py
@@ -1,0 +1,32 @@
+"""Regression guard for project_manager.py's PRISM_MODALITIES, which is now
+derived from src/entity_rules.py instead of a hardcoded literal list.
+"""
+
+import os
+import sys
+
+current_dir = os.path.dirname(os.path.abspath(__file__))
+project_root = os.path.dirname(current_dir)
+app_path = os.path.join(project_root, "app")
+
+if app_path not in sys.path:
+    sys.path.insert(0, app_path)
+
+from src.project_manager import BIDS_PASSTHROUGH_MODALITIES, PRISM_MODALITIES
+
+
+def test_prism_modalities_matches_previously_hardcoded_set():
+    # Order is no longer guaranteed to match the old hardcoded list exactly
+    # (nothing depends on it - see get_available_modalities() and its one
+    # test, which mocks the function out entirely), so compare as a set.
+    assert set(PRISM_MODALITIES) == {
+        "survey", "biometrics", "environment", "physio", "eyetracking", "events",
+    }
+
+
+def test_bids_passthrough_modalities_unchanged():
+    assert BIDS_PASSTHROUGH_MODALITIES == {"eyetracking"}
+
+
+def test_prism_modalities_is_a_plain_list():
+    assert isinstance(PRISM_MODALITIES, list)

--- a/tests/verify_repo.py
+++ b/tests/verify_repo.py
@@ -1382,8 +1382,6 @@ def check_schema_sync(repo_path, fix=False):
 
     schema_dir = os.path.join(repo_path, "app", "schemas", "stable")
     schema_manager_file = os.path.join(repo_path, "app", "src", "schema_manager.py")
-    validator_file = os.path.join(repo_path, "app", "src", "validator.py")
-    project_manager_file = os.path.join(repo_path, "app", "src", "project_manager.py")
     index_html_file = os.path.join(repo_path, "app", "templates", "index.html")
 
     if not os.path.isdir(schema_dir):
@@ -1395,6 +1393,7 @@ def check_schema_sync(repo_path, fix=False):
         "project",
         "recipe.survey",
         "tool-limesurvey",
+        "entities",  # filename/entity rules file, not a per-modality content schema
     }
     schema_modalities = set()
     for path in Path(schema_dir).glob("*.schema.json"):
@@ -1406,21 +1405,8 @@ def check_schema_sync(repo_path, fix=False):
     manager_modalities_raw = _extract_assignment_values(
         schema_manager_file, "modalities"
     )
-    validator_modalities_raw = _extract_assignment_values(
-        validator_file, "MODALITY_PATTERNS"
-    )
-    project_modalities_raw = _extract_assignment_values(
-        project_manager_file, "PRISM_MODALITIES"
-    )
-
     if manager_modalities_raw is None:
         print_error("Could not parse modalities list in app/src/schema_manager.py")
-        return
-    if validator_modalities_raw is None:
-        print_error("Could not parse MODALITY_PATTERNS in app/src/validator.py")
-        return
-    if project_modalities_raw is None:
-        print_error("Could not parse PRISM_MODALITIES in app/src/project_manager.py")
         return
 
     aliases = {"physiological": "physio"}
@@ -1434,8 +1420,6 @@ def check_schema_sync(repo_path, fix=False):
         return normalized
 
     manager_modalities = normalize_modalities(manager_modalities_raw)
-    validator_modalities = normalize_modalities(validator_modalities_raw)
-    project_modalities = normalize_modalities(project_modalities_raw)
 
     if schema_modalities != manager_modalities:
         missing = sorted(schema_modalities - manager_modalities)
@@ -1448,23 +1432,37 @@ def check_schema_sync(repo_path, fix=False):
         if extra:
             print(f"  Extra in schema_manager: {', '.join(extra)}")
 
-    if schema_modalities != validator_modalities:
-        missing = sorted(schema_modalities - validator_modalities)
-        extra = sorted(validator_modalities - schema_modalities)
-        print_error("validator MODALITY_PATTERNS are out of sync with schemas.")
-        if missing:
-            print(f"  Missing in MODALITY_PATTERNS: {', '.join(missing)}")
-        if extra:
-            print(f"  Extra in MODALITY_PATTERNS: {', '.join(extra)}")
+    # validator.py's MODALITY_PATTERNS/PRISM_MODALITIES and
+    # project_manager.py's PRISM_MODALITIES are no longer hardcoded literals
+    # - both are derived at import time from src/entity_rules.py (see that
+    # module's docstring). A static ast-literal extractor can't see through
+    # that derivation anymore, so import the real, resolved value instead.
+    # entity_rules.py + schema_manager.py have zero third-party dependencies
+    # (stdlib only), so this stays consistent with this script's fast,
+    # dependency-light design.
+    repo_root = str(Path(repo_path).resolve())
+    if repo_root not in sys.path:
+        sys.path.insert(0, repo_root)
+    try:
+        from src.entity_rules import load_entity_rules
 
-    if schema_modalities != project_modalities:
-        missing = sorted(schema_modalities - project_modalities)
-        extra = sorted(project_modalities - schema_modalities)
-        print_error("project_manager PRISM_MODALITIES are out of sync with schemas.")
+        rules = load_entity_rules(schema_dir=os.path.join(repo_path, "app", "schemas"))
+        entity_rules_modalities = set(rules.project_modalities)
+    except Exception as e:
+        print_error(f"Could not load src/entity_rules.py: {e}")
+        return
+
+    if schema_modalities != entity_rules_modalities:
+        missing = sorted(schema_modalities - entity_rules_modalities)
+        extra = sorted(entity_rules_modalities - schema_modalities)
+        print_error(
+            "entities.schema.json modalities (validator.py/project_manager.py's "
+            "derived modality lists) are out of sync with app/schemas/stable."
+        )
         if missing:
-            print(f"  Missing in PRISM_MODALITIES: {', '.join(missing)}")
+            print(f"  Missing in entities.schema.json: {', '.join(missing)}")
         if extra:
-            print(f"  Extra in PRISM_MODALITIES: {', '.join(extra)}")
+            print(f"  Extra in entities.schema.json: {', '.join(extra)}")
 
     if os.path.exists(index_html_file):
         try:


### PR DESCRIPTION
## Summary
Follow-up to #81/#82/#84, migrating the last identified set of hardcoded modality-list duplicates:

- New `EntityRules.project_modalities` property (`src/entity_rules.py`): modality identities with their own filename-suffix grammar, excluding alias names (`"physiological"`) and pure-BIDS-passthrough entries with no suffix data (`anat`/`func`/etc.) - includes `eyetracking`, which has suffix data despite being validated as BIDS-passthrough.
- `project_manager.py`'s `PRISM_MODALITIES` now derives from `entity_rules.project_modalities` instead of a hardcoded 6-item list.
- `bids_integration.py`'s `prism_folders` (inside `check_and_update_bidsignore`) now derives from `entity_rules.prism_modalities` instead of a hardcoded 8-item set - drops two dead/vestigial entries: `"eeg"` (already in `STANDARD_BIDS_FOLDERS`, so it never survived the existing filter - a proven no-op removal) and `"metadata"` (unreferenced anywhere else in the codebase).

**Confirmed unrelated to, and untouched:** the DataLad text-file/git-annex policy. `DATALAD_TEXT_POLICY_REQUIRED_LINES` (`.gitattributes` rules) is a static, extension-only tuple with zero connection to any modality-name list - nothing here touches it or could affect it.

## Bonus: fixes a real regression from #81
While mapping this out I found `tests/verify_repo.py --check schema-sync` was silently broken by #81. It statically parses `validator.py`'s `MODALITY_PATTERNS` via `ast`, expecting a literal `dict`/`list`/`set` - #81 turned it into a dict comprehension, which the AST extractor can't handle, so the check has been printing `[✗] Could not parse MODALITY_PATTERNS` instead of actually verifying anything since #81 merged.

Rewrote `check_schema_sync` to import the real, resolved `src/entity_rules.py` value instead of parsing `validator.py`/`project_manager.py`'s source text (`entity_rules.py` + `schema_manager.py` have zero third-party dependencies, so this stays consistent with the script's fast, dependency-light design). This is now the actual regression gate for this PR - confirmed passing:
```
[✓] Schema modality touchpoints are in sync.
```

## Test plan
- [x] New tests in `tests/test_entity_rules.py`, `tests/test_bids_integration.py`, `tests/test_project_manager_modalities.py` (8 new tests) - confirm the derived sets match the prior hardcoded ones (as sets, not exact order - nothing depends on order), and confirm `"eeg"`/`"metadata"` never produce a `.bidsignore` line before or after
- [x] `pytest tests/ -q` - 2745 passed, 1 pre-existing unrelated failure (same one noted in #80/#81/#82/#84)
- [x] `python tests/verify_repo.py --check schema-sync` - now passes (was silently broken since #81)
- [x] `tests/verify_repo.py --check ruff,mypy` - ruff clean; mypy clean on all touched files (3 pre-existing errors elsewhere, unrelated)

🤖 Generated with [Claude Code](https://claude.com/claude-code)