### PR TITLE
Refactor project validation and metadata handling

### DIFF
--- a/app/src/project_manager.py
+++ b/app/src/project_manager.py
@@ -6132,7 +6132,7 @@ Subfolders:
         if upper in mapping:
             return mapping[upper]
 
-        if upper == "OTHER":
+        if upper in ("OTHER", "NOT DECIDED YET"):
             return ""
 
         if re.match(r"^[A-Za-z0-9][A-Za-z0-9+\.-]*$", normalized):
@@ -7730,7 +7730,7 @@ Subfolders:
             "DatasetDOI": self._clean_citation_source_text(
                 description.get("DatasetDOI")
             ),
-            "License": self._clean_citation_source_text(description.get("License")),
+            "License": self._normalize_license_value(description.get("License")),
             "HowToAcknowledge": self._clean_citation_source_text(
                 description.get("HowToAcknowledge")
             ),

--- a/app/src/system_files.py
+++ b/app/src/system_files.py
@@ -29,6 +29,7 @@ SYSTEM_FILES = {
     ".gitignore",  # Git ignore file
     ".svn",  # Subversion
     ".hg",  # Mercurial
+    ".datalad",  # DataLad internal metadata directory
     ".idea",  # IntelliJ IDEA
     ".vscode",  # Visual Studio Code
     "__pycache__",  # Python cache

--- a/app/static/css/projects/metadata.css
+++ b/app/static/css/projects/metadata.css
@@ -21,6 +21,16 @@
     border-top: 1px dashed #d7dce1;
 }
 
+.section-completeness-row--clickable {
+    cursor: pointer;
+    border-radius: 4px;
+}
+.section-completeness-row--clickable:hover,
+.section-completeness-row--clickable:focus-visible {
+    background-color: rgba(13, 110, 253, 0.08);
+    outline: none;
+}
+
 .section-completeness-row-citation .section-label {
     font-weight: 600;
 }

--- a/app/static/css/results.css
+++ b/app/static/css/results.css
@@ -57,7 +57,7 @@
         transform: rotate(180deg);
     }
     .revalidate-form {
-        flex-wrap: wrap;
+        flex-wrap: nowrap;
     }
     .revalidate-mode-select {
         min-width: 230px;
@@ -73,6 +73,7 @@
     @media (max-width: 768px) {
         .revalidate-form {
             width: 100%;
+            flex-wrap: wrap;
         }
 
         .revalidate-mode-select {

--- a/app/static/js/modules/projects/metadata.js
+++ b/app/static/js/modules/projects/metadata.js
@@ -165,8 +165,8 @@ const studyMetadataLoadController = createStudyMetadataLoadController({
 
         const missingData = sm.MissingData || {};
         document.getElementById('smMissingDesc').value = missingData.Description || '';
-        document.getElementById('smMissingFiles').value = missingData.MissingFiles || '';
-        document.getElementById('smKnownIssues').value = missingData.KnownIssues || '';
+        setTwoFieldList('smMissingFiles', missingData.MissingFiles || '');
+        setTwoFieldList('smKnownIssues', missingData.KnownIssues || '');
 
         document.getElementById('smReferencesText').value = Array.isArray(sm.References)
             ? sm.References.join('\n')
@@ -1440,6 +1440,144 @@ function initOverviewListFields() {
     });
 }
 
+// ===== TWO-FIELD TABLE ROWS (Missing Files / Known Issues) =====
+// Each row combines two short text values (e.g. "SubjectID | What's missing")
+// into a single "field1 | field2" line. Rows are joined with newlines into
+// the same hidden textarea format the backend already stores as plain text,
+// so no backend changes are needed for this UI-only structuring.
+
+const TWO_FIELD_LIST_FIELDS = {
+    smMissingFiles: {
+        listId: 'smMissingFilesList',
+        addId: 'smMissingFilesAddRow',
+        field1Placeholder: 'Subject/session ID (e.g. sub-002, ses-2)',
+        field2Placeholder: "What's missing (e.g. T1w, task-rest)",
+    },
+    smKnownIssues: {
+        listId: 'smKnownIssuesList',
+        addId: 'smKnownIssuesAddRow',
+        field1Placeholder: 'Filename (e.g. sub-002_task-nback_bold.nii)',
+        field2Placeholder: 'Issue description (e.g. Shorter scan)',
+    },
+};
+
+function _combineTwoFieldRow(field1, field2) {
+    const clean1 = _cleanMetadataText(field1);
+    const clean2 = _cleanMetadataText(field2);
+    if (clean1 && clean2) return `${clean1} | ${clean2}`;
+    return clean1 || clean2;
+}
+
+function _parseTwoFieldListValue(rawValue) {
+    const text = String(rawValue || '').trim();
+    if (!text) return [];
+    return text.split('\n').map(line => line.trim()).filter(Boolean).map(line => {
+        const pipeIndex = line.indexOf('|');
+        if (pipeIndex === -1) return { field1: line, field2: '' };
+        return {
+            field1: line.slice(0, pipeIndex).trim(),
+            field2: line.slice(pipeIndex + 1).trim(),
+        };
+    });
+}
+
+function _syncTwoFieldListField(fieldId) {
+    const config = TWO_FIELD_LIST_FIELDS[fieldId];
+    const hiddenField = document.getElementById(fieldId);
+    const list = document.getElementById(config?.listId || '');
+    if (!config || !hiddenField || !list) return;
+
+    const values = Array.from(list.querySelectorAll('.two-field-row'))
+        .map(row => _combineTwoFieldRow(
+            row.querySelector('.two-field-input-1')?.value || '',
+            row.querySelector('.two-field-input-2')?.value || ''
+        ))
+        .filter(Boolean);
+    hiddenField.value = values.join('\n');
+    updateCreateProjectButton();
+}
+
+function addTwoFieldRow(fieldId, field1 = '', field2 = '') {
+    const config = TWO_FIELD_LIST_FIELDS[fieldId];
+    const list = document.getElementById(config?.listId || '');
+    if (!config || !list) return;
+
+    const row = document.createElement('div');
+    row.className = 'input-group input-group-sm two-field-row';
+
+    const input1 = document.createElement('input');
+    input1.type = 'text';
+    input1.className = 'form-control two-field-input-1';
+    input1.placeholder = config.field1Placeholder;
+    input1.value = String(field1 || '');
+
+    const input2 = document.createElement('input');
+    input2.type = 'text';
+    input2.className = 'form-control two-field-input-2';
+    input2.placeholder = config.field2Placeholder;
+    input2.value = String(field2 || '');
+
+    const removeButton = document.createElement('button');
+    removeButton.type = 'button';
+    removeButton.className = 'btn btn-outline-danger two-field-row-remove';
+    removeButton.setAttribute('aria-label', 'Remove entry');
+    removeButton.innerHTML = '<i class="fas fa-times"></i>';
+
+    const onInput = () => _syncTwoFieldListField(fieldId);
+    input1.addEventListener('input', onInput);
+    input2.addEventListener('input', onInput);
+
+    removeButton.addEventListener('click', () => {
+        row.remove();
+        if (!list.querySelector('.two-field-row')) {
+            addTwoFieldRow(fieldId);
+        }
+        _syncTwoFieldListField(fieldId);
+    });
+
+    row.appendChild(input1);
+    row.appendChild(input2);
+    row.appendChild(removeButton);
+    list.appendChild(row);
+    _syncTwoFieldListField(fieldId);
+}
+
+function setTwoFieldList(fieldId, rawValue) {
+    const config = TWO_FIELD_LIST_FIELDS[fieldId];
+    const list = document.getElementById(config?.listId || '');
+    if (!config || !list) return;
+
+    list.innerHTML = '';
+    const entries = _parseTwoFieldListValue(rawValue);
+    if (!entries.length) {
+        addTwoFieldRow(fieldId);
+        return;
+    }
+
+    entries.forEach(entry => addTwoFieldRow(fieldId, entry.field1, entry.field2));
+    _syncTwoFieldListField(fieldId);
+}
+
+function initTwoFieldListFields() {
+    Object.entries(TWO_FIELD_LIST_FIELDS).forEach(([fieldId, config]) => {
+        const addButton = document.getElementById(config.addId);
+        if (addButton && !addButton.dataset.bound) {
+            addButton.dataset.bound = '1';
+            addButton.addEventListener('click', () => {
+                addTwoFieldRow(fieldId);
+                const list = document.getElementById(config.listId);
+                const lastInput = list?.querySelector('.two-field-row:last-child .two-field-input-1');
+                lastInput?.focus();
+            });
+        }
+
+        const list = document.getElementById(config.listId);
+        if (list && !list.querySelector('.two-field-row')) {
+            addTwoFieldRow(fieldId);
+        }
+    });
+}
+
 // ===== RECRUITMENT LOCATIONS =====
 
 export function toggleRecLocationInputs() {
@@ -1757,48 +1895,26 @@ export function validateAllMandatoryFields() {
     const requiredInvalidFields = [];
     const optionalInvalidFields = [];
 
+    // Only fields in creationBlockingFields (see computeLocalCompleteness) ever
+    // reach the emptyFields loop below, so this only needs to label those.
     const labels = {
         Basics: {
-            Name: 'Dataset Name (min. 3 characters)',
-            Authors: 'Authors (at least 1)',
-            Keywords: 'Keywords (at least 3)',
-            EthicsApprovals: 'Ethics Approvals (select Yes or No)',
-            Funding: 'Funding (select Yes or No)'
-        },
-        Overview: {
-            Main: 'Dataset Overview'
-        },
-        StudyDesign: {
-            Type: 'Study Design Type'
-        },
-        Recruitment: {
-            Method: 'Recruitment Method',
-            Location: 'Recruitment Location',
-            'Period.Start': 'Recruitment Period Start',
-            'Period.End': 'Recruitment Period End',
-            Compensation: 'Financial Compensation'
-        },
-        Eligibility: {
-            InclusionCriteria: 'Eligibility Criteria (at least 2 total across inclusion and exclusion)'
-        },
-        Procedure: {
-            Overview: 'Procedure Overview'
+            Name: 'Dataset Name (min. 3 characters)'
         }
     };
 
+    // Only fields that gate project creation land in emptyFields. Everything
+    // else marked `required` is readiness-only (see creationBlockingFields in
+    // computeLocalCompleteness) and is surfaced through the FAIR/methods
+    // readiness score instead of blocking creation.
     Object.entries(completeness.sections || {}).forEach(([sectionName, section]) => {
         (section.fields || []).forEach(field => {
-            if (!field.required || field.filled) return;
+            if (!field.blocksCreation || field.filled) return;
             if (sectionName === 'Basics' && field.name === 'Authors') return;
             const friendlyLabel = labels[sectionName]?.[field.name] || `${sectionName}: ${field.name}`;
             emptyFields.push(friendlyLabel);
         });
     });
-
-    const periodError = getRecPeriodRangeError();
-    if (periodError) {
-        requiredInvalidFields.push(periodError);
-    }
 
     const datasetName = _cleanMetadataText(document.getElementById('metadataName')?.value || '');
     if (datasetName.length > 0 && datasetName.length < 3) {
@@ -1821,22 +1937,22 @@ export function validateAllMandatoryFields() {
         }
     }
 
-    if (!hasEthicsChoice()) {
-        requiredInvalidFields.push('Please select Ethics Approvals: Yes or No.');
-    } else if (!hasValidEthicsResponse()) {
-        requiredInvalidFields.push('Ethics details are required when Ethics Approvals is set to Yes.');
+    // Recruitment period, ethics, and funding are readiness-tier: an unmade
+    // choice never blocks creation. An inconsistent *made* choice (e.g. an
+    // invalid date range, or "Yes" with no supporting details) is a genuine
+    // data error and is still flagged, just as a non-blocking-until-wrong
+    // optional issue rather than a missing-field issue.
+    const periodError = getRecPeriodRangeError();
+    if (periodError) {
+        optionalInvalidFields.push(periodError);
     }
 
-    if (!hasFundingChoice()) {
-        requiredInvalidFields.push('Please select Funding: Yes or No.');
-    } else if (!hasValidFundingResponse()) {
-        requiredInvalidFields.push('Funding details are required when Funding is set to Yes.');
+    if (hasEthicsChoice() && !hasValidEthicsResponse()) {
+        optionalInvalidFields.push('Ethics details are required when Ethics Approvals is set to Yes.');
     }
 
-    const keywords = (document.getElementById('metadataKeywords')?.value || '')
-        .split(',').map(s => _cleanMetadataText(s)).filter(Boolean);
-    if (keywords.length < 3) {
-        requiredInvalidFields.push('At least 3 Keywords are required (comma-separated).');
+    if (hasFundingChoice() && !hasValidFundingResponse()) {
+        optionalInvalidFields.push('Funding details are required when Funding is set to Yes.');
     }
 
     const doiValue = _cleanMetadataText(document.getElementById('metadataDOI')?.value || '');
@@ -2301,6 +2417,7 @@ export function updateCreateProjectButton() {
 const mandatoryFieldIds = [
     'metadataName',
     'metadataKeywords',
+    'metadataLicense',
     'smOverviewMain', 'smSDType', 'smRecMethod',
     'smRecPeriodStartYear', 'smRecPeriodStartMonth',
     'smRecPeriodEndYear', 'smRecPeriodEndMonth',
@@ -2890,7 +3007,6 @@ export function setFundingChoice(choice) {
     const yesBtn = document.getElementById('metadataFundingYes');
     const noBtn = document.getElementById('metadataFundingNo');
     const declaredInput = document.getElementById('metadataFundingDeclared');
-    const fundingField = document.getElementById('metadataFunding');
 
     if (!yesBtn || !noBtn || !declaredInput) return;
 
@@ -2911,8 +3027,8 @@ export function setFundingChoice(choice) {
         group.classList.toggle('sm-choice-missing', normalized === '');
     }
 
-    if (normalized !== 'yes' && fundingField) {
-        fundingField.value = '';
+    if (normalized !== 'yes') {
+        setFundingRows([]);
     }
 
     toggleFundingFields();
@@ -2926,17 +3042,149 @@ function hasFundingChoice() {
     return declaredInput.value === 'yes' || declaredInput.value === 'no';
 }
 
+// ===== FUNDING SOURCE ROWS =====
+// One row per funding source (agency + grant number), combined into a single
+// opaque string per BIDS Funding array entry. Rows are joined with newlines
+// (never commas) in the #metadataFunding mirror field so an agency/grant
+// pair like "NSF, Award 12345" is never mis-split into two entries.
+
+function _combineFundingRow(agency, grant) {
+    const cleanAgency = _cleanMetadataText(agency);
+    const cleanGrant = _cleanMetadataText(grant);
+    if (cleanAgency && cleanGrant) return `${cleanAgency}, ${cleanGrant}`;
+    return cleanAgency || cleanGrant;
+}
+
+function _syncFundingListField() {
+    const hiddenField = document.getElementById('metadataFunding');
+    const list = document.getElementById('metadataFundingList');
+    if (!hiddenField || !list) return;
+
+    const values = Array.from(list.querySelectorAll('.funding-row'))
+        .map(row => _combineFundingRow(
+            row.querySelector('.funding-agency-input')?.value || '',
+            row.querySelector('.funding-grant-input')?.value || ''
+        ))
+        .filter(Boolean);
+    hiddenField.value = values.join('\n');
+
+    try {
+        validateFundingBadge();
+    } catch (_) {
+        // no-op: validator may not be wired in all contexts
+    }
+}
+
+export function addFundingRow(agency = '', grant = '') {
+    const list = document.getElementById('metadataFundingList');
+    if (!list) return;
+
+    const row = document.createElement('div');
+    row.className = 'input-group input-group-sm funding-row';
+
+    const agencyInput = document.createElement('input');
+    agencyInput.type = 'text';
+    agencyInput.className = 'form-control funding-agency-input';
+    agencyInput.placeholder = 'Funding agency (e.g. NSF, FWF)';
+    agencyInput.value = String(agency || '');
+
+    const grantInput = document.createElement('input');
+    grantInput.type = 'text';
+    grantInput.className = 'form-control funding-grant-input';
+    grantInput.placeholder = 'Grant / award number (optional)';
+    grantInput.value = String(grant || '');
+
+    const removeButton = document.createElement('button');
+    removeButton.type = 'button';
+    removeButton.className = 'btn btn-outline-danger funding-row-remove';
+    removeButton.setAttribute('aria-label', 'Remove funding source');
+    removeButton.innerHTML = '<i class="fas fa-times"></i>';
+
+    const onInput = () => {
+        _syncFundingListField();
+        updateCreateProjectButton();
+    };
+    agencyInput.addEventListener('input', onInput);
+    grantInput.addEventListener('input', onInput);
+
+    removeButton.addEventListener('click', () => {
+        row.remove();
+        if (!list.querySelector('.funding-row')) {
+            addFundingRow();
+        }
+        _syncFundingListField();
+        updateCreateProjectButton();
+    });
+
+    row.appendChild(agencyInput);
+    row.appendChild(grantInput);
+    row.appendChild(removeButton);
+    list.appendChild(row);
+    _syncFundingListField();
+}
+
+function setFundingRows(entries) {
+    const list = document.getElementById('metadataFundingList');
+    if (!list) return;
+
+    list.innerHTML = '';
+    if (!entries.length) {
+        addFundingRow();
+        return;
+    }
+
+    entries.forEach(entry => {
+        const text = _cleanMetadataText(entry);
+        if (!text) return;
+        // Legacy/loaded entries are opaque "Agency, Grant" strings; split on
+        // the first comma only, for a cosmetic agency/grant split in the UI.
+        const commaIndex = text.indexOf(',');
+        if (commaIndex === -1) {
+            addFundingRow(text, '');
+        } else {
+            addFundingRow(text.slice(0, commaIndex).trim(), text.slice(commaIndex + 1).trim());
+        }
+    });
+    if (!list.querySelector('.funding-row')) {
+        addFundingRow();
+    }
+    _syncFundingListField();
+}
+
+function initFundingRows() {
+    const addButton = document.getElementById('metadataFundingAddRow');
+    if (addButton && !addButton.dataset.bound) {
+        addButton.dataset.bound = '1';
+        addButton.addEventListener('click', () => {
+            addFundingRow();
+            const list = document.getElementById('metadataFundingList');
+            const lastInput = list?.querySelector('.funding-row:last-child .funding-agency-input');
+            lastInput?.focus();
+            updateCreateProjectButton();
+        });
+    }
+
+    const list = document.getElementById('metadataFundingList');
+    if (list && !list.querySelector('.funding-row')) {
+        addFundingRow();
+    }
+}
+
 export function getFundingList() {
     const declaredInput = document.getElementById('metadataFundingDeclared');
-    const fundingField = document.getElementById('metadataFunding');
     if (!declaredInput) return [];
-
     if (declaredInput.value !== 'yes') return [];
 
-    return (fundingField?.value || '')
-        .split(',')
-        .map(s => _cleanMetadataText(s))
-        .filter(Boolean);
+    const rows = document.querySelectorAll('#metadataFundingList .funding-row');
+    const entries = [];
+    rows.forEach(row => {
+        const combined = _combineFundingRow(
+            row.querySelector('.funding-agency-input')?.value || '',
+            row.querySelector('.funding-grant-input')?.value || ''
+        );
+        if (combined) entries.push(combined);
+    });
+    return entries;
 }
 
 function hasValidFundingResponse() {
@@ -2949,19 +3197,16 @@ function hasValidFundingResponse() {
 }
 
 function setFundingFromDescription(fundingValues) {
-    const fundingField = document.getElementById('metadataFunding');
-    if (!fundingField) return;
-
     const values = Array.isArray(fundingValues)
         ? fundingValues
         : (fundingValues ? [fundingValues] : []);
     const cleaned = values.map(v => _cleanMetadataText(v)).filter(Boolean);
 
     if (cleaned.length > 0) {
-        fundingField.value = cleaned.join(', ');
+        setFundingRows(cleaned);
         setFundingChoice('yes');
     } else {
-        fundingField.value = '';
+        setFundingRows([]);
         setFundingChoice('no');
     }
 }
@@ -3004,8 +3249,10 @@ export function computeLocalCompleteness() {
     let filledFields = 0;
     let totalFields = 0;
 
+    // Fields scored toward FAIR/methods readiness. Missing these lowers the
+    // readiness score and shows a CORE badge, but does not block project creation.
     const requiredFields = {
-        Basics: new Set(['Name', 'Authors', 'Keywords', 'EthicsApprovals', 'Funding']),
+        Basics: new Set(['Name', 'Authors', 'Keywords', 'EthicsApprovals', 'Funding', 'License']),
         Overview: new Set(['Main']),
         StudyDesign: new Set(['Type']),
         Recruitment: new Set(['Method', 'Location', 'Period.Start', 'Period.End', 'Compensation']),
@@ -3013,8 +3260,18 @@ export function computeLocalCompleteness() {
         Procedure: new Set(['Overview'])
     };
 
+    // Minimal subset that actually gates project creation (triggers the
+    // incomplete-metadata confirmation). Everything else in requiredFields is
+    // readiness-only: researchers often cannot know it yet at creation time
+    // (e.g. recruitment period, compensation) or should not be forced to
+    // decide it immediately (e.g. ethics/funding/keywords).
+    const creationBlockingFields = {
+        Basics: new Set(['Name', 'Authors'])
+    };
+
     const addField = (section, name, isFilled) => {
         const isRequired = requiredFields[section]?.has(name) || false;
+        const blocksCreation = creationBlockingFields[section]?.has(name) || false;
         if (!sections[section]) {
             sections[section] = {
                 fields: [],
@@ -3029,7 +3286,7 @@ export function computeLocalCompleteness() {
                 read_only: false
             };
         }
-        sections[section].fields.push({ name, filled: isFilled, priority: 1, hint: '', required: isRequired });
+        sections[section].fields.push({ name, filled: isFilled, priority: 1, hint: '', required: isRequired, blocksCreation });
         sections[section].total += 1;
         sections[section].weight_total += 1;
         if (isRequired) {
@@ -3184,10 +3441,12 @@ export function updateCompletenessUI(completeness) {
         Eligibility: 'Eligibility',
         Procedure: 'Procedure',
         MissingData: 'Missing Data & Issues',
-        References: 'References'
+        References: 'Background Literature'
     };
 
     let html = '';
+    let nextActionKey = null;
+    let nextActionRatio = 1;
     for (const key of sectionOrder) {
         const sec = sections[key];
         if (!sec) continue;
@@ -3195,6 +3454,17 @@ export function updateCompletenessUI(completeness) {
         const reqFilled = sec.required_filled || 0;
         const optTotal = sec.optional_total || 0;
         const optFilled = sec.optional_filled || 0;
+
+        // Track the least-complete CORE-tier section as the "next best step"
+        // toward a higher readiness score. Ties keep the earliest section in
+        // sectionOrder, which already runs in the order researchers fill it in.
+        if (!sec.read_only && reqTotal > 0 && reqFilled < reqTotal) {
+            const ratio = reqFilled / reqTotal;
+            if (nextActionKey === null || ratio < nextActionRatio) {
+                nextActionKey = key;
+                nextActionRatio = ratio;
+            }
+        }
         const baseTotal = reqTotal > 0 ? reqTotal : sec.total;
         const baseFilled = reqTotal > 0 ? reqFilled : sec.filled;
         const pct = baseTotal > 0 ? Math.round(baseFilled / baseTotal * 100) : 0;
@@ -3207,11 +3477,12 @@ export function updateCompletenessUI(completeness) {
         else if (pct > 0) dotClass = 'partial';
 
         const autoLabel = sec.read_only ? ' <span class="text-muted small">(auto)</span>' : '';
-        html += `<div class="section-completeness-row">
+        const rowClickable = !sec.read_only;
+        html += `<div class="section-completeness-row${rowClickable ? ' section-completeness-row--clickable' : ''}"${rowClickable ? ` data-section-key="${key}" role="button" tabindex="0"` : ''}>
             <span class="section-label">${sectionLabels[key] || key}${autoLabel}</span>
             <span class="completeness-dot ${dotClass}" title="${pct}%"></span>
             <span class="section-badge">
-                <span class="${reqTextClass}">Required ${reqFilled}/${reqTotal}</span>
+                <span class="${reqTextClass}">Core ${reqFilled}/${reqTotal}</span>
                 <span class="text-muted"> • </span>
                 <span class="${fairTextClass}">FAIR ${optFilled}/${optTotal}</span>
             </span>
@@ -3222,7 +3493,7 @@ export function updateCompletenessUI(completeness) {
             const reqClass = reqDone ? 'bg-success' : 'bg-danger';
             const fairClass = fairDone ? 'bg-success' : 'bg-warning text-dark';
             badgeEl.innerHTML = `
-                <span class="badge ${reqClass} bg-opacity-75">Required ${reqFilled}/${reqTotal}</span>
+                <span class="badge ${reqClass} bg-opacity-75">Core ${reqFilled}/${reqTotal}</span>
                 <span class="badge ${fairClass} bg-opacity-75">FAIR ${optFilled}/${optTotal}</span>
             `;
         }
@@ -3287,6 +3558,41 @@ export function updateCompletenessUI(completeness) {
     html += renderMetadataRepairHint();
 
     dotsDiv.innerHTML = html;
+    _updateFairNextActionHint(nextActionKey, sectionLabels);
+}
+
+function _updateFairNextActionHint(sectionKey, sectionLabels) {
+    const button = document.getElementById('smFairNextAction');
+    if (!button) return;
+
+    if (!sectionKey) {
+        button.classList.add('d-none');
+        button.onclick = null;
+        return;
+    }
+
+    button.classList.remove('d-none');
+    button.innerHTML = `<i class="fas fa-arrow-right me-1"></i>Next best step: complete ${sectionLabels[sectionKey] || sectionKey}`;
+    button.onclick = () => _jumpToSection(sectionKey);
+}
+
+function _jumpToSection(sectionKey) {
+    const collapseId = 'sm' + sectionKey;
+    const collapseEl = document.getElementById(collapseId);
+    const toggleButton = document.querySelector(`[data-bs-target="#${collapseId}"]`);
+
+    if (collapseEl && window.bootstrap?.Collapse) {
+        window.bootstrap.Collapse.getOrCreateInstance(collapseEl, { toggle: false }).show();
+    }
+
+    const scrollTarget = toggleButton || collapseEl;
+    scrollTarget?.scrollIntoView({ behavior: 'smooth', block: 'center' });
+
+    // Focus the first empty field inside the section once it has expanded.
+    setTimeout(() => {
+        const firstEmptyField = collapseEl?.querySelector('.required-field-empty, .funding-row .funding-agency-input:placeholder-shown');
+        firstEmptyField?.focus();
+    }, 250);
 }
 
 const studyMetadataForm = document.getElementById('studyMetadataForm');
@@ -3314,7 +3620,21 @@ if (smSectionDots) {
         if (regenerateCitationBtn) {
             event.preventDefault();
             regenerateCitationCff();
+            return;
         }
+
+        const sectionRow = event.target.closest('[data-section-key]');
+        if (sectionRow) {
+            _jumpToSection(sectionRow.dataset.sectionKey);
+        }
+    });
+
+    smSectionDots.addEventListener('keydown', (event) => {
+        if (event.key !== 'Enter' && event.key !== ' ') return;
+        const sectionRow = event.target.closest('[data-section-key]');
+        if (!sectionRow) return;
+        event.preventDefault();
+        _jumpToSection(sectionRow.dataset.sectionKey);
     });
 }
 
@@ -3547,6 +3867,8 @@ document.addEventListener('DOMContentLoaded', function() {
         }
     });
     initOverviewListFields();
+    initFundingRows();
+    initTwoFieldListFields();
     initRecMethodPicker();
     toggleRecLocationInputs();
     initYearMonthSelect('smRecPeriodStartYear', 'smRecPeriodStartMonth');

--- a/app/static/js/modules/projects/validation.js
+++ b/app/static/js/modules/projects/validation.js
@@ -320,6 +320,7 @@ function updateBadgeColor(badge, isFilled) {
         removeClass(badge, 'bg-danger');
         removeClass(badge, 'bg-warning');
         removeClass(badge, 'bg-secondary');
+        removeClass(badge, 'bg-primary');
         removeClass(badge, 'text-dark');
         addClass(badge, 'bg-success');
         debugLog(`Badge "${badgeText}" turned GREEN`);
@@ -329,6 +330,9 @@ function updateBadgeColor(badge, isFilled) {
         if (text === 'REQUIRED') {
             addClass(badge, 'bg-danger');
             debugLog(`Badge "${badgeText}" turned RED`);
+        } else if (text === 'CORE') {
+            addClass(badge, 'bg-primary');
+            debugLog(`Badge "${badgeText}" turned BLUE (readiness-tier, not creation-blocking)`);
         } else if (text === 'RECOMMENDED') {
             addClass(badge, 'bg-warning');
             addClass(badge, 'text-dark');
@@ -613,11 +617,14 @@ export function resetAllBadges() {
         removeClass(badge, 'bg-warning');
         removeClass(badge, 'bg-secondary');
         removeClass(badge, 'bg-success');
+        removeClass(badge, 'bg-primary');
         removeClass(badge, 'text-dark');
-        
+
         // Re-apply original color based on badge type
         if (badgeText === 'REQUIRED') {
             addClass(badge, 'bg-danger');
+        } else if (badgeText === 'CORE') {
+            addClass(badge, 'bg-primary');
         } else if (badgeText === 'RECOMMENDED') {
             addClass(badge, 'bg-warning');
             addClass(badge, 'text-dark');

--- a/app/templates/includes/projects/study_metadata.html
+++ b/app/templates/includes/projects/study_metadata.html
@@ -23,20 +23,23 @@
                         <div class="progress-bar" role="progressbar" id="smMainProgressBar" style="width: 0%"></div>
                     </div>
                     <span class="fw-bold" id="smMainScore">0%</span>
-                    <div class="sm-fair-motivation" id="smFairMotivation" aria-label="FAIR readiness 0%" data-score="0">
+                    <div class="sm-fair-motivation" id="smFairMotivation" aria-label="FAIR readiness 0%" data-score="0"
+                         data-bs-toggle="tooltip" data-bs-placement="top" data-bs-html="true"
+                         title="<strong>Methods Readiness / FAIR score</strong><br>Share of CORE and optional fields you've filled in across all sections below. It does not block project creation &mdash; it tracks how reusable and FAIR-compliant your documentation is.">
                         <div class="sm-fair-ring" id="smFairRing" style="--fair-progress: 0;">
                             <span class="sm-fair-label">FAIR</span>
                         </div>
                         <small class="sm-fair-percent" id="smFairPercent">0%</small>
                     </div>
                 </div>
+                <button type="button" class="btn btn-link btn-sm p-0 mb-2 d-none" id="smFairNextAction"></button>
                 <div id="smSectionDots"></div>
             </div>
 
             <div class="alert alert-primary border-0 bg-primary bg-opacity-10 py-2 mb-3 beginner-help-block" id="smNewProjectInfo" style="display: none;">
                 <i class="fas fa-lightbulb me-2"></i>
-                For a new project, fill out all fields marked <span class="badge bg-danger">REQUIRED</span> first.
-                Once required fields are complete, project creation is enabled.
+                For a new project, fill out <span class="badge bg-danger">REQUIRED</span> fields to enable project creation.
+                <span class="badge bg-primary">CORE</span> fields are not required to create the project, but they drive your Methods Readiness / FAIR score below — fill them in as soon as you can.
             </div>
 
             <form id="studyMetadataForm" novalidate>
@@ -61,7 +64,7 @@
                             <div id="metadataValidationFeedback" class="mb-3" style="display: none;"></div>
                             <div class="sm-basics-intro mb-3">
                                 <div class="sm-basics-intro__eyebrow">Start here</div>
-                                <p class="sm-basics-intro__copy mb-0">Complete the identity and compliance fields first. The citation and sharing details below can be filled in once the project scaffold is stable.</p>
+                                <p class="sm-basics-intro__copy mb-0">Complete the identity, ethics, keywords, and funding fields first. The DOI, HED, and other discovery details below can be filled in once the project scaffold is stable.</p>
                             </div>
                             <div class="row g-3">
                                 <div class="col-md-12 col-lg-6">
@@ -84,7 +87,7 @@
                                 </div>
                                 <div class="col-md-12 col-lg-6">
                                     <label class="form-label fw-bold small text-muted text-uppercase mb-1">
-                                        <span class="badge bg-warning text-dark">RECOMMENDED</span> License
+                                        <span class="badge bg-primary" id="metadataLicenseRequiredBadge">CORE</span> License
                                         <i class="fas fa-info-circle text-muted ms-1"
                                            data-bs-toggle="tooltip"
                                            data-bs-placement="right"
@@ -98,6 +101,7 @@ Avoid SA / NC variants if you want your data indexed in major repositories."
                                     </label>
                                     <select class="form-select form-select-sm" id="metadataLicense">
                                         <option value="">Select a license...</option>
+                                        <option value="Not decided yet">Not decided yet</option>
                                         <option value="CC0">CC0 (Public Domain)</option>
                                         <option value="CC BY 4.0">CC BY 4.0</option>
                                         <option value="CC BY-SA 4.0">CC BY-SA 4.0</option>
@@ -108,6 +112,7 @@ Avoid SA / NC variants if you want your data indexed in major repositories."
                                         <option value="Other">Other/Proprietary</option>
                                     </select>
                                     <small class="text-muted">
+                                        A missing license is the most common reason shared data cannot legally be reused. Pick "Not decided yet" if you are not ready to choose &mdash; that still counts as an explicit answer.
                                         Synced to dataset_description.json and CITATION.cff. &nbsp;
                                         <a href="https://creativecommons.org/choose/" target="_blank" rel="noopener" class="text-muted">
                                             <i class="fas fa-external-link-alt me-1" style="font-size:0.7em;"></i>Help me choose
@@ -131,8 +136,58 @@ Avoid SA / NC variants if you want your data indexed in major repositories."
                                     <textarea class="form-control form-control-sm" id="metadataAcknowledgements" rows="2" placeholder="Funding, grants, people to thank..."></textarea>
                                 </div>
                                 <div class="col-md-12">
+                                    <label class="form-label fw-bold small text-muted text-uppercase mb-1">
+                                        <span class="badge bg-primary" id="metadataEthicsRequiredBadge">CORE</span> Ethics Approvals
+                                    </label>
+                                    <div class="mb-2">
+                                        <input type="hidden" id="metadataEthicsApproved" value="">
+                                        <div class="btn-group btn-group-sm sm-choice-group" id="metadataEthicsChoiceGroup" role="group" aria-label="Ethics approvals">
+                                            <button type="button" class="btn btn-outline-primary" id="metadataEthicsYes">Yes</button>
+                                            <button type="button" class="btn btn-outline-primary" id="metadataEthicsNo">No</button>
+                                        </div>
+                                    </div>
+                                    <div id="ethicsDetailsSection" style="display: none; margin-top: 12px;">
+                                        <div class="row g-2">
+                                            <div class="col-md-6">
+                                                <input type="text" class="form-control form-control-sm" id="metadataEthicsCommittee" placeholder="Example: Ethics Committee Name" required>
+                                            </div>
+                                            <div class="col-md-6">
+                                                <input type="text" class="form-control form-control-sm" id="metadataEthicsVotum" placeholder="Example: EK-2026-014" required>
+                                            </div>
+                                        </div>
+                                    </div>
+                                    <small class="text-muted">If approved, add the committee name and reference number. Placeholder text is never saved.</small>
+                                </div>
+                                <div class="col-md-12">
+                                    <label class="form-label fw-bold small text-muted text-uppercase mb-1">
+                                        <span class="badge bg-primary">CORE</span> Keywords (comma-separated)
+                                    </label>
+                                    <input type="text" class="form-control form-control-sm" id="metadataKeywords" placeholder="psychology, experiment, PRISM">
+                                    <small class="text-muted">Enter at least three keywords so the dataset is schema-complete and easier to find later.</small>
+                                </div>
+                                <div class="col-md-12">
+                                    <label class="form-label fw-bold small text-muted text-uppercase mb-1">
+                                        <span class="badge bg-primary" id="metadataFundingRequiredBadge">CORE</span> Funding
+                                    </label>
+                                    <div class="mb-2">
+                                        <input type="hidden" id="metadataFundingDeclared" value="">
+                                        <div class="btn-group btn-group-sm sm-choice-group" id="metadataFundingChoiceGroup" role="group" aria-label="Funding declared">
+                                            <button type="button" class="btn btn-outline-primary" id="metadataFundingYes">Yes</button>
+                                            <button type="button" class="btn btn-outline-primary" id="metadataFundingNo">No</button>
+                                        </div>
+                                    </div>
+                                    <div id="fundingDetailsSection" style="display: none; margin-top: 12px;">
+                                        <div id="metadataFundingList" class="d-flex flex-column gap-2 mb-2"></div>
+                                        <button type="button" class="btn btn-outline-secondary btn-sm" id="metadataFundingAddRow">
+                                            <i class="fas fa-plus me-1"></i>Add Funding Source
+                                        </button>
+                                        <input type="hidden" id="metadataFunding" value="">
+                                    </div>
+                                    <small class="text-muted">If funding exists, add one row per funding source with its agency and grant number.</small>
+                                </div>
+                                <div class="col-md-12">
                                     <div class="sm-basics-secondary-panel mt-3 pt-3 border-top">
-                                        <div class="sm-basics-secondary-panel__eyebrow">Citation and sharing details</div>
+                                        <div class="sm-basics-secondary-panel__eyebrow">Discovery and citation details</div>
                                         <p class="sm-basics-secondary-panel__copy mb-3">These fields refine discovery, reuse, and formal citation. They are useful, but they do not have to block the first save.</p>
                                         <div class="row g-3">
                                             <div class="col-md-6">
@@ -152,58 +207,12 @@ Avoid SA / NC variants if you want your data indexed in major repositories."
                                                     <option value="derivative">derivative</option>
                                                 </select>
                                             </div>
-                                            <div class="col-md-12">
-                                                <label class="form-label fw-bold small text-muted text-uppercase mb-1">
-                                                    <span class="badge bg-danger" id="metadataEthicsRequiredBadge">REQUIRED</span> Ethics Approvals
-                                                </label>
-                                                <div class="mb-2">
-                                                    <input type="hidden" id="metadataEthicsApproved" value="">
-                                                    <div class="btn-group btn-group-sm sm-choice-group" id="metadataEthicsChoiceGroup" role="group" aria-label="Ethics approvals">
-                                                        <button type="button" class="btn btn-outline-primary" id="metadataEthicsYes">Yes</button>
-                                                        <button type="button" class="btn btn-outline-primary" id="metadataEthicsNo">No</button>
-                                                    </div>
-                                                </div>
-                                                <div id="ethicsDetailsSection" style="display: none; margin-top: 12px;">
-                                                    <div class="row g-2">
-                                                        <div class="col-md-6">
-                                                            <input type="text" class="form-control form-control-sm" id="metadataEthicsCommittee" placeholder="Example: Ethics Committee Name" required>
-                                                        </div>
-                                                        <div class="col-md-6">
-                                                            <input type="text" class="form-control form-control-sm" id="metadataEthicsVotum" placeholder="Example: EK-2026-014" required>
-                                                        </div>
-                                                    </div>
-                                                </div>
-                                                <small class="text-muted">If approved, add the committee name and reference number. Placeholder text is never saved.</small>
-                                            </div>
                                             <div class="col-md-6">
                                                 <label class="form-label fw-bold small text-muted text-uppercase mb-1">
                                                     <span class="badge bg-secondary">OPTIONAL</span> HED Version
                                                 </label>
                                                 <input type="text" class="form-control form-control-sm" id="metadataHED" placeholder="Example: 8.2.0">
                                                 <small class="text-muted">Leave empty unless the dataset uses HED tags. <a href="https://www.hedtags.org" target="_blank" rel="noopener noreferrer">What is HED?</a></small>
-                                            </div>
-                                            <div class="col-md-12">
-                                                <label class="form-label fw-bold small text-muted text-uppercase mb-1">
-                                                    <span class="badge bg-danger">REQUIRED</span> Keywords (comma-separated)
-                                                </label>
-                                                <input type="text" class="form-control form-control-sm" id="metadataKeywords" placeholder="psychology, experiment, PRISM">
-                                                <small class="text-muted">Enter at least three keywords so the dataset is schema-complete and easier to find later.</small>
-                                            </div>
-                                            <div class="col-md-12">
-                                                <label class="form-label fw-bold small text-muted text-uppercase mb-1">
-                                                    <span class="badge bg-danger" id="metadataFundingRequiredBadge">REQUIRED</span> Funding
-                                                </label>
-                                                <div class="mb-2">
-                                                    <input type="hidden" id="metadataFundingDeclared" value="">
-                                                    <div class="btn-group btn-group-sm sm-choice-group" id="metadataFundingChoiceGroup" role="group" aria-label="Funding declared">
-                                                        <button type="button" class="btn btn-outline-primary" id="metadataFundingYes">Yes</button>
-                                                        <button type="button" class="btn btn-outline-primary" id="metadataFundingNo">No</button>
-                                                    </div>
-                                                </div>
-                                                <div id="fundingDetailsSection" style="display: none; margin-top: 12px;">
-                                                    <input type="text" class="form-control form-control-sm" id="metadataFunding" placeholder="National Science Foundation (NSF) Grant #1234567, Other funding sources">
-                                                </div>
-                                                <small class="text-muted">If funding exists, list the agency and grant numbers separated by commas.</small>
                                             </div>
                                             <div class="col-md-12">
                                                 <label class="form-label fw-bold small text-muted text-uppercase mb-1">
@@ -214,10 +223,10 @@ Avoid SA / NC variants if you want your data indexed in major repositories."
                                             </div>
                                             <div class="col-md-12">
                                                 <label class="form-label fw-bold small text-muted text-uppercase mb-1">
-                                                    <span class="badge bg-secondary">OPTIONAL</span> References &amp; Links
+                                                    <span class="badge bg-secondary">OPTIONAL</span> Citation Links
                                                 </label>
                                                 <textarea class="form-control form-control-sm" id="metadataReferences" rows="2" placeholder="https://doi.org/..., https://example.com/..." ></textarea>
-                                                <small class="text-muted">Add URLs or citations separated by commas. They sync into the citation metadata automatically.</small>
+                                                <small class="text-muted">Add URLs or citations separated by commas. They sync into CITATION.cff and dataset_description.json.</small>
                                             </div>
                                         </div>
                                     </div>
@@ -242,7 +251,7 @@ Avoid SA / NC variants if you want your data indexed in major repositories."
                             <div class="row g-3">
                                 <div class="col-12">
                                     <label class="form-label fw-bold small">
-                                        <span class="badge bg-danger">REQUIRED</span> Dataset Overview
+                                        <span class="badge bg-primary">CORE</span> Dataset Overview
                                     </label>
                                     <textarea class="form-control form-control-sm" id="smOverviewMain" rows="4"
                                               placeholder="A brief paragraph describing the goals, purpose, and unique value of this dataset..."></textarea>
@@ -308,7 +317,7 @@ Avoid SA / NC variants if you want your data indexed in major repositories."
                             <div class="row g-3">
                                 <div class="col-md-4">
                                     <label class="form-label fw-bold small">
-                                        <span class="badge bg-danger">REQUIRED</span> Study Design Type
+                                        <span class="badge bg-primary">CORE</span> Study Design Type
                                     </label>
                                     <select class="form-select form-select-sm" id="smSDType">
                                         <option value="">-- Select --</option>
@@ -386,7 +395,7 @@ Avoid SA / NC variants if you want your data indexed in major repositories."
                             <div class="row g-3">
                                 <div class="col-md-6">
                                     <label class="form-label fw-bold small">
-                                        <span class="badge bg-danger" id="smRecMethodRequiredBadge">REQUIRED</span> Method
+                                        <span class="badge bg-primary" id="smRecMethodRequiredBadge">CORE</span> Method
                                     </label>
                                     <!-- Hidden backing select (existing API surface) -->
                                     <select class="d-none" id="smRecMethod" multiple aria-hidden="true" tabindex="-1">
@@ -425,7 +434,7 @@ Avoid SA / NC variants if you want your data indexed in major repositories."
                                 </div>
                                 <div class="col-md-6">
                                     <label class="form-label fw-bold small">
-                                        <span class="badge bg-danger" id="smRecLocationRequiredBadge">REQUIRED</span> Location
+                                        <span class="badge bg-primary" id="smRecLocationRequiredBadge">CORE</span> Location
                                     </label>
                                     <!-- Location search picker -->
                                     <div class="input-group input-group-sm flex-nowrap mb-1" id="recLocationPickerGroup">
@@ -454,7 +463,7 @@ Avoid SA / NC variants if you want your data indexed in major repositories."
                                 </div>
                                 <div class="col-md-3">
                                     <label class="form-label fw-bold small">
-                                        <span class="badge bg-danger" id="smRecPeriodStartRequiredBadge">REQUIRED</span> Period Start
+                                        <span class="badge bg-primary" id="smRecPeriodStartRequiredBadge">CORE</span> Period Start
                                     </label>
                                     <div class="d-flex gap-2">
                                         <select class="form-select form-select-sm" id="smRecPeriodStartYear" required></select>
@@ -463,7 +472,7 @@ Avoid SA / NC variants if you want your data indexed in major repositories."
                                 </div>
                                 <div class="col-md-3">
                                     <label class="form-label fw-bold small">
-                                        <span class="badge bg-danger" id="smRecPeriodEndRequiredBadge">REQUIRED</span> Period End
+                                        <span class="badge bg-primary" id="smRecPeriodEndRequiredBadge">CORE</span> Period End
                                     </label>
                                     <div class="d-flex gap-2">
                                         <select class="form-select form-select-sm" id="smRecPeriodEndYear" required></select>
@@ -472,7 +481,7 @@ Avoid SA / NC variants if you want your data indexed in major repositories."
                                 </div>
                                 <div class="col-md-3">
                                     <label class="form-label fw-bold small">
-                                        <span class="badge bg-danger">REQUIRED</span> Financial Compensation
+                                        <span class="badge bg-primary">CORE</span> Financial Compensation
                                     </label>
                                     <select class="form-select form-select-sm" id="smRecCompensation" required>
                                         <option value="">-- Select --</option>
@@ -500,7 +509,7 @@ Avoid SA / NC variants if you want your data indexed in major repositories."
                             <div class="row g-3">
                                 <div class="col-md-6">
                                     <label class="form-label fw-bold small">
-                                        <span class="badge bg-danger" id="smEligCriteriaRequiredBadge">REQUIRED</span> Inclusion Criteria
+                                        <span class="badge bg-primary" id="smEligCriteriaRequiredBadge">CORE</span> Inclusion Criteria
                                     </label>
                                     <textarea class="form-control form-control-sm d-none" id="smEligInclusion" rows="3"
                                               placeholder="One criterion per line" aria-hidden="true" tabindex="-1"></textarea>
@@ -555,7 +564,7 @@ Avoid SA / NC variants if you want your data indexed in major repositories."
                             <div class="row g-3">
                                 <div class="col-12">
                                     <label class="form-label fw-bold small">
-                                        <span class="badge bg-danger">REQUIRED</span> Overview
+                                        <span class="badge bg-primary">CORE</span> Overview
                                     </label>
                                     <textarea class="form-control form-control-sm" id="smProcOverview" rows="3"
                                               placeholder="Narrative overview of the study procedure..."></textarea>
@@ -641,15 +650,21 @@ Avoid SA / NC variants if you want your data indexed in major repositories."
                                 </div>
                                 <div class="col-12">
                                     <label class="form-label fw-bold small">Missing Files (Table)</label>
-                                    <textarea class="form-control form-control-sm" id="smMissingFiles" rows="3"
-                                              placeholder="Format: sub-001 | T1w, task-rest&#10;sub-002 | ses-2 functional scans"></textarea>
-                                    <small class="text-muted">One entry per line: SubjectID | What's missing</small>
+                                    <textarea class="form-control form-control-sm d-none" id="smMissingFiles" rows="3" aria-hidden="true" tabindex="-1"></textarea>
+                                    <div id="smMissingFilesList" class="d-flex flex-column gap-2 mb-2"></div>
+                                    <button type="button" class="btn btn-outline-secondary btn-sm" id="smMissingFilesAddRow">
+                                        <i class="fas fa-plus me-1"></i>Add Entry
+                                    </button>
+                                    <small class="text-muted d-block mt-1">One row per subject: SubjectID, then what's missing.</small>
                                 </div>
                                 <div class="col-12">
                                     <label class="form-label fw-bold small">Known Issues (Table)</label>
-                                    <textarea class="form-control form-control-sm" id="smKnownIssues" rows="3"
-                                              placeholder="Format: sub-001_task-nback_bold.nii | Shorter scan&#10;sub-002_T1w.nii | Resolution differs"></textarea>
-                                    <small class="text-muted">One entry per line: Filename | Issue description</small>
+                                    <textarea class="form-control form-control-sm d-none" id="smKnownIssues" rows="3" aria-hidden="true" tabindex="-1"></textarea>
+                                    <div id="smKnownIssuesList" class="d-flex flex-column gap-2 mb-2"></div>
+                                    <button type="button" class="btn btn-outline-secondary btn-sm" id="smKnownIssuesAddRow">
+                                        <i class="fas fa-plus me-1"></i>Add Entry
+                                    </button>
+                                    <small class="text-muted d-block mt-1">One row per file: Filename, then the issue description.</small>
                                 </div>
                             </div>
                         </div>
@@ -661,19 +676,19 @@ Avoid SA / NC variants if you want your data indexed in major repositories."
                     <button class="btn btn-sm btn-outline-secondary w-100 text-start sm-section-toggle" type="button"
                             data-bs-toggle="collapse" data-bs-target="#smReferences" aria-expanded="false" aria-controls="smReferences">
                         <span class="sm-section-toggle__titleline">
-                            <span class="sm-section-toggle__title"><i class="fas fa-book me-1"></i> References</span>
+                            <span class="sm-section-toggle__title"><i class="fas fa-book me-1"></i> Background Literature</span>
                             <span class="sm-section-toggle__badge" id="smReferencesBadge"></span>
                         </span>
-                        <span class="sm-section-toggle__summary">Store citations and supporting references that should feed into the README and reporting outputs.</span>
+                        <span class="sm-section-toggle__summary">Cite related papers, prior work, or supporting literature to include in the README. Not the same as the Citation Links field under Basics, which feeds CITATION.cff.</span>
                     </button>
                     <div class="collapse" id="smReferences">
                         <div class="card card-body border-0 bg-light mt-1">
                             <div class="row g-3">
                                 <div class="col-12">
-                                    <label class="form-label fw-bold small">References</label>
+                                    <label class="form-label fw-bold small">Background Literature</label>
                                     <textarea class="form-control form-control-sm" id="smReferencesText" rows="4"
                                               placeholder="One reference per line or formatted citations..."></textarea>
-                                    <small class="text-muted">References used within the README</small>
+                                    <small class="text-muted">Included in the README, separate from the Citation Links field above (which feeds CITATION.cff).</small>
                                 </div>
                             </div>
                         </div>

--- a/app/templates/results.html
+++ b/app/templates/results.html
@@ -12,12 +12,14 @@
         <div class="d-flex justify-content-between align-items-center flex-wrap gap-3 mb-4">
             <div>
                 {% set results_dataset_label = results.dataset_name if results and results.dataset_name else filename %}
-                {% set results_header_note = 'Schema Version: ' ~ results.schema_version if results and results.get('schema_version') else '' %}
+                {% set results_header_subtitle = 'Dataset: ' ~ results_dataset_label %}
+                {% if results and results.get('schema_version') %}
+                {% set results_header_subtitle = results_header_subtitle ~ ' • Schema Version: ' ~ results.schema_version %}
+                {% endif %}
                 {{ page_header(
                     'fas fa-chart-line',
                     'Validation Results',
-                    'Dataset: ' ~ results_dataset_label,
-                    results_header_note
+                    results_header_subtitle
                 ) }}
             </div>
             <div class="d-flex flex-wrap align-items-center justify-content-end gap-2">

--- a/tests/test_project_manager.py
+++ b/tests/test_project_manager.py
@@ -4044,6 +4044,34 @@ class TestProjectManager(unittest.TestCase):
         self.assertEqual(basics.get("EthicsApprovals"), ["EK-2026-001"])
         self.assertEqual(basics.get("Authors"), ["Jane Doe"])
 
+    def test_sync_dataset_metadata_to_project_json_drops_undecided_license_sentinel(
+        self,
+    ):
+        """The 'Not decided yet' placeholder must never be persisted as a License value."""
+        manager = ProjectManager()
+
+        with tempfile.TemporaryDirectory() as tmp:
+            project_path = Path(tmp)
+            (project_path / "project.json").write_text(
+                json.dumps({"name": "old-name", "Basics": {}}),
+                encoding="utf-8",
+            )
+
+            manager.sync_dataset_metadata_to_project_json(
+                project_path,
+                {
+                    "Name": "new-name",
+                    "License": "Not decided yet",
+                },
+            )
+
+            payload = json.loads(
+                (project_path / "project.json").read_text(encoding="utf-8")
+            )
+
+        basics = payload.get("Basics") or {}
+        self.assertEqual(basics.get("License"), "")
+
     def test_build_citation_config_prefers_project_json_dataset_links(self):
         manager = ProjectManager()
 

--- a/tests/test_projects_compact_view_wiring.py
+++ b/tests/test_projects_compact_view_wiring.py
@@ -57,7 +57,7 @@ class TestProjectsCompactViewWiring(unittest.TestCase):
 
         self.assertIn('class="sm-basics-intro mb-3"', content)
         self.assertIn('class="sm-basics-secondary-panel mt-3 pt-3 border-top"', content)
-        self.assertIn('Citation and sharing details', content)
+        self.assertIn('Discovery and citation details', content)
 
     def test_projects_header_has_preliminary_badge_placeholder(self):
         content = PROJECTS_TEMPLATE.read_text(encoding="utf-8")

--- a/tests/test_runner.py
+++ b/tests/test_runner.py
@@ -314,6 +314,22 @@ class TestValidateDataset:
                 for msg in warning_messages
             )
 
+    def test_datalad_metadata_dir_in_derivatives_is_ignored(self, tmp_path):
+        """DataLad's internal .datalad dir under derivatives/ must not be treated as a pipeline."""
+        (tmp_path / "dataset_description.json").write_text(
+            '{"Name": "Root dataset", "BIDSVersion": "1.8.0"}',
+            encoding="utf-8",
+        )
+        (tmp_path / "derivatives" / ".datalad").mkdir(parents=True)
+
+        issues, _stats = validate_dataset(str(tmp_path), verbose=False)
+
+        warning_messages = [issue[1] for issue in issues if issue[0] == "WARNING"]
+        assert not any(
+            "Derivatives dataset '.datalad' is missing dataset_description.json" in msg
+            for msg in warning_messages
+        )
+
     def test_bids_only_mode_skips_prism_specific_checks(self, monkeypatch, tmp_path):
         """BIDS-only runs must not include PRISM-only consistency/derivative checks."""
         (tmp_path / "derivatives" / "pipeline").mkdir(parents=True)


### PR DESCRIPTION
- Update badge color logic in validation.js to include 'CORE' badge with blue color.
- Enhance study_metadata.html to clarify the role of 'CORE' fields in project creation and FAIR score.
- Modify results.html to improve dataset header display with schema version.
- Add unit test to ensure 'Not decided yet' license placeholder is not persisted in project.json.
- Update compact view tests to reflect changes in terminology from 'Citation and sharing details' to 'Discovery and citation details'.
- Implement test to ignore DataLad's internal .datalad directory under derivatives during validation.