### PR TITLE
Ponytail audit: dedup, dead-code removal, and shrink cleanups

### DIFF
--- a/app/src/_compat.py
+++ b/app/src/_compat.py
@@ -111,8 +111,13 @@ def load_canonical_module(
         )
         return _caller_module_fallback()
 
-    # Canonical path is always repo_root/src/<canonical_rel_path>.
-    repo_root = canonical_path.parent.parent
+    # Canonical path is always repo_root/src/<canonical_rel_path>, where
+    # canonical_rel_path may itself contain subdirectories (e.g.
+    # "maintenance/sync_survey_keys.py"). Walk up one level per path
+    # component plus one more for "src" itself, rather than assuming a
+    # fixed two-level hop — a fixed hop only works when canonical_rel_path
+    # is a bare filename with no subdirectory.
+    repo_root = canonical_path.parents[len(Path(canonical_rel_path).parts)]
 
     repo_root_str = str(repo_root)
     if repo_root_str not in sys.path:

--- a/app/src/cli/commands/convert.py
+++ b/app/src/cli/commands/convert.py
@@ -21,24 +21,7 @@ from src.converters.wide_to_long import (
 )
 from src.cross_platform import normalize_path
 from src.entity_rules import load_entity_rules
-
-
-def sanitize_id(id_str):
-    """Sanitize subject/session IDs by replacing German umlauts and special characters."""
-    if not id_str:
-        return id_str
-    replacements = {
-        "ä": "ae",
-        "ö": "oe",
-        "ü": "ue",
-        "Ä": "Ae",
-        "Ö": "Oe",
-        "Ü": "Ue",
-        "ß": "ss",
-    }
-    for char, repl in replacements.items():
-        id_str = id_str.replace(char, repl)
-    return id_str
+from src.utils.naming import sanitize_id
 
 
 def _normalize_physio_suffix(raw_suffix: str | None) -> str:

--- a/app/src/converters/survey.py
+++ b/app/src/converters/survey.py
@@ -173,8 +173,10 @@ def _find_matching_global_template(
 
 
 _MISSING_TOKEN = "n/a"  # noqa: S105 - placeholder value for missing survey answers, not a credential
-# LimeSurvey answer code max length (used for reverse lookup)
-_LS_ANSWER_CODE_MAX_LENGTH = 5
+
+# Reuse the canonical implementation (survey_processing already imported as
+# _survey_processing above) instead of hand-rolling a second copy.
+_sanitize_answer_code_for_ls = _survey_processing._sanitize_answer_code_for_ls
 
 
 def _normalize_run_id(value: object) -> str | None:
@@ -186,32 +188,6 @@ def _normalize_run_id(value: object) -> str | None:
     if not label:
         return None
     return f"run-{label}"
-
-
-def _sanitize_answer_code_for_ls(code: str) -> str:
-    """Apply LimeSurvey answer code sanitization (for reverse lookup).
-
-    This mirrors the logic in limesurvey_exporter._sanitize_answer_code()
-    to allow matching truncated codes back to original level keys.
-
-    LimeSurvey truncates answer codes to 5 chars using: first 3 + last 2 chars
-    after removing non-alphanumeric characters.
-    """
-    # Handle n/a specially
-    if code.lower() in ("n/a", "na"):
-        return "na"
-
-    # Remove non-alphanumeric characters
-    sanitized = re.sub(r"[^a-zA-Z0-9]", "", code)
-
-    if len(sanitized) <= _LS_ANSWER_CODE_MAX_LENGTH:
-        return sanitized.lower()
-
-    # For long codes: first 3 chars + last 2 chars
-    prefix_len = _LS_ANSWER_CODE_MAX_LENGTH - 2  # 3
-    suffix_len = 2
-    abbreviated = sanitized[:prefix_len] + sanitized[-suffix_len:]
-    return abbreviated.lower()
 
 
 def _find_matching_level_key(value: str, levels: dict) -> str | None:

--- a/app/src/converters/survey_core.py
+++ b/app/src/converters/survey_core.py
@@ -14,7 +14,6 @@ from __future__ import annotations
 
 import json
 import os
-import re
 from copy import deepcopy
 from dataclasses import dataclass
 from pathlib import Path
@@ -26,6 +25,7 @@ except ImportError:
     from src.survey_scale_inference import apply_implicit_numeric_level_ranges
 
 from src.entity_rules import load_entity_rules
+from src.converters import survey_processing as _survey_processing
 
 try:
     import pandas as pd
@@ -116,23 +116,10 @@ def _build_bids_survey_filename(
     acq: str | None = None,
 ) -> str:
     """Build a BIDS-compliant survey filename."""
-
-    def _normalize_run_entity(value: str | int | None) -> str | None:
-        if value is None:
-            return None
-        text = str(value).strip()
-        if not text:
-            return None
-        label = text[4:] if text[:4].lower() == "run-" else text
-        label = re.sub(r"[^A-Za-z0-9]+", "", label)
-        if not label:
-            return None
-        return f"run-{label}"
-
     parts = [sub_id, ses_id, f"task-{task}"]
     if acq:
         parts.append(f"acq-{acq}")
-    normalized_run = _normalize_run_entity(run)
+    normalized_run = _survey_processing.normalize_run_entity(run)
     if normalized_run is not None:
         parts.append(normalized_run)
     parts.append(_SURVEY_SUFFIX)  # Add suffix without extension

--- a/app/src/converters/survey_io.py
+++ b/app/src/converters/survey_io.py
@@ -71,16 +71,7 @@ def _preview_display_path(file_path: str | Path, output_root: str | Path) -> str
 
 
 def _normalize_run_entity(value: str | int | None) -> str | None:
-    if value is None:
-        return None
-    text = str(value).strip()
-    if not text or text.lower() == "nan":
-        return None
-    label = text[4:] if text[:4].lower() == "run-" else text
-    label = re.sub(r"[^A-Za-z0-9]+", "", label)
-    if not label:
-        return None
-    return f"run-{label}"
+    return _survey_processing.normalize_run_entity(value, nan_as_none=True)
 
 
 def _lookup_task_context_value(

--- a/app/src/converters/survey_processing.py
+++ b/app/src/converters/survey_processing.py
@@ -96,6 +96,39 @@ def _sanitize_answer_code_for_ls(code: str) -> str:
     return abbreviated.lower()
 
 
+def normalize_run_entity(
+    value: object,
+    *,
+    nan_as_none: bool = False,
+    raise_on_empty_label: bool = False,
+) -> str | None:
+    """Normalize a BIDS `run-<label>` entity value.
+
+    Strips an existing ``run-`` prefix, removes non-alphanumeric characters,
+    and re-prefixes. Two call-site-specific edge cases are opt-in:
+
+    - ``nan_as_none``: treat the literal string ``"nan"`` (pandas' stringified
+      missing-float marker) the same as an empty value.
+    - ``raise_on_empty_label``: raise ``ValueError`` (instead of returning
+      ``None``) when the value is non-empty but becomes empty after removing
+      non-alphanumeric characters (e.g. ``"---"``).
+    """
+    if value is None:
+        return None
+    text = str(value).strip()
+    if not text or (nan_as_none and text.lower() == "nan"):
+        return None
+    label = text[4:] if text[:4].lower() == "run-" else text
+    label = re.sub(r"[^A-Za-z0-9]+", "", label)
+    if not label:
+        if raise_on_empty_label:
+            raise ValueError(
+                "Invalid template version selection payload. Run must contain only letters and numbers."
+            )
+        return None
+    return f"run-{label}"
+
+
 def _find_matching_level_key(value: str, levels: dict) -> str | None:
     v_lower = value.lower().strip()
 

--- a/app/src/project_manager.py
+++ b/app/src/project_manager.py
@@ -6802,34 +6802,32 @@ git push -u origin main
 
     def _create_bidsignore(self, modalities: List[str]) -> str:
         """Create .bidsignore content."""
-        content = "# .bidsignore - PRISM and YODA files excluded from BIDS validation\n"
-        content += (
-            "# This ensures compatibility with standard BIDS tools (fMRIPrep, etc.)\n\n"
+        lines = [
+            "# .bidsignore - PRISM and YODA files excluded from BIDS validation",
+            "# This ensures compatibility with standard BIDS tools (fMRIPrep, etc.)",
+            "",
+            "project.json",
+            ".prismrc.json",
+            "",
+            "sourcedata/",
+            "derivatives/",
+            "analysis/",
+            "paper/",
+            "code/",
+            "",
+            "recipes/",
+            "recipe/",
+            "library/",
+            "code/recipes/",
+            "code/library/",
+            "",
+        ]
+        lines.extend(
+            f"{mod}/"
+            for mod in modalities
+            if mod in PRISM_MODALITIES and mod not in BIDS_PASSTHROUGH_MODALITIES
         )
-
-        # Ignore project-level metadata
-        content += "project.json\n"
-        content += ".prismrc.json\n\n"
-
-        # Ignore YODA folders (they are outside rawdata/ but just in case)
-        content += "sourcedata/\n"
-        content += "derivatives/\n"
-        content += "analysis/\n"
-        content += "paper/\n"
-        content += "code/\n\n"
-
-        # Ignore legacy/non-BIDS project folders if present
-        content += "recipes/\n"
-        content += "recipe/\n"
-        content += "library/\n"
-        content += "code/recipes/\n"
-        content += "code/library/\n\n"
-
-        for mod in modalities:
-            if mod in PRISM_MODALITIES and mod not in BIDS_PASSTHROUGH_MODALITIES:
-                content += f"{mod}/\n"
-
-        return content
+        return "\n".join(lines) + "\n"
 
     def _create_prismrc(self) -> Dict[str, Any]:
         """Create .prismrc.json content."""

--- a/app/src/validator.py
+++ b/app/src/validator.py
@@ -235,20 +235,23 @@ def resolve_sidecar_path(file_path, root_dir, library_path=None):
     return candidate
 
 
-def _deep_merge(base: dict, override: dict) -> dict:
+def _deep_merge(base: object, override: object) -> object:
     """
-    Deep merge two dictionaries. Override values take precedence.
+    Deep merge two values. Override values take precedence.
 
-    For nested dicts, recursively merge. For other types, override replaces base.
-    This implements BIDS inheritance where subject-level values override root-level.
+    For nested dicts, recursively merge; for anything else, override replaces
+    base outright. This implements BIDS inheritance where subject-level
+    values override root-level values.
     """
-    result = base.copy()
-    for key, value in override.items():
-        if key in result and isinstance(result[key], dict) and isinstance(value, dict):
-            result[key] = _deep_merge(result[key], value)
-        else:
-            result[key] = value
-    return result
+    if isinstance(base, dict) and isinstance(override, dict):
+        result = dict(base)
+        for key, value in override.items():
+            if key in result:
+                result[key] = _deep_merge(result[key], value)
+            else:
+                result[key] = value
+        return result
+    return override
 
 
 def _find_inherited_root_sidecar(file_path: str, root_dir: str) -> str | None:

--- a/app/src/web/blueprints/conversion_utils.py
+++ b/app/src/web/blueprints/conversion_utils.py
@@ -10,6 +10,7 @@ from flask import current_app
 import pandas as pd
 from src.converters.file_reader import infer_tabular_kind, read_tabular_file
 from src.utils.naming import normalize_filename
+from src.converters.survey_processing import normalize_run_entity as _normalize_run_entity
 
 SEPARATOR_MAP: dict[str, str] = {
     "comma": ",",
@@ -118,19 +119,6 @@ def _coerce_template_version_value(raw_value: object) -> str:
     return ""
 
 
-def _normalize_run_entity(run_value: object) -> str | None:
-    text = str(run_value or "").strip()
-    if not text:
-        return None
-    label = text[4:] if text[:4].lower() == "run-" else text
-    label = re.sub(r"[^A-Za-z0-9]+", "", label)
-    if not label:
-        raise ValueError(
-            "Invalid template version selection payload. Run must contain only letters and numbers."
-        )
-    return f"run-{label}"
-
-
 def parse_template_version_overrides(
     raw_value: str | None,
 ) -> dict[str, str] | list[dict[str, object]]:
@@ -171,7 +159,7 @@ def parse_template_version_overrides(
             run_entity = None
             if run_value not in {None, ""}:
                 try:
-                    run_entity = _normalize_run_entity(run_value)
+                    run_entity = _normalize_run_entity(run_value, raise_on_empty_label=True)
                 except ValueError as exc:
                     raise ValueError(str(exc)) from exc
             if run_entity is None and session_name is None:
@@ -213,7 +201,7 @@ def parse_template_version_overrides(
         run_value = entry.get("run")
         if run_value not in {None, ""}:
             try:
-                run_entity = _normalize_run_entity(run_value)
+                run_entity = _normalize_run_entity(run_value, raise_on_empty_label=True)
             except ValueError as exc:
                 raise ValueError(str(exc)) from exc
         overrides.append(

--- a/app/src/web/blueprints/tools_helpers.py
+++ b/app/src/web/blueprints/tools_helpers.py
@@ -8,7 +8,6 @@ from src.prism_template_validation import (
     strip_template_editor_internal_keys as _strip_template_editor_internal_keys,
     validate_template_against_schema as _validate_against_schema,
 )
-from src.validator import _deep_merge
 
 
 def _default_library_root_for_templates(*, modality: str) -> Path:

--- a/app/src/web/blueprints/tools_helpers.py
+++ b/app/src/web/blueprints/tools_helpers.py
@@ -8,6 +8,7 @@ from src.prism_template_validation import (
     strip_template_editor_internal_keys as _strip_template_editor_internal_keys,
     validate_template_against_schema as _validate_against_schema,
 )
+from src.validator import _deep_merge
 
 
 def _default_library_root_for_templates(*, modality: str) -> Path:
@@ -251,18 +252,6 @@ def _schema_example(schema: dict) -> object:
         return None
 
     return ""
-
-
-def _deep_merge(base: object, override: object) -> object:
-    if isinstance(base, dict) and isinstance(override, dict):
-        out = dict(base)
-        for key, value in override.items():
-            if key in out:
-                out[key] = _deep_merge(out[key], value)
-            else:
-                out[key] = value
-        return out
-    return override
 
 
 def _new_template_from_schema(*, modality: str, schema_version: str | None) -> dict:

--- a/app/static/js/modules/converter/biometrics.js
+++ b/app/static/js/modules/converter/biometrics.js
@@ -607,7 +607,7 @@ export function initBiometrics(elements) {
                 abortErrorMessage: 'Biometrics polling aborted due to project change.',
                 timeoutErrorMessage: 'Biometrics conversion status timed out after 2 hours. The conversion may still be running in the background -- check the project for partial results before retrying.',
                 statusFailureMessage: 'Failed to retrieve conversion status after multiple attempts.',
-                getFailureError: (status) => status.error || errorMessage,
+                failureMessage: errorMessage,
             });
             return statusData.result || {};
         } finally {

--- a/app/static/js/modules/converter/biometrics.js
+++ b/app/static/js/modules/converter/biometrics.js
@@ -9,6 +9,7 @@ import { resolveCurrentProjectPath } from '../../shared/project-state.js';
 import { createJobRunController } from './job-run-controller.js';
 import { createPollingRunState, isPollingAbortError } from './polling-run-state.js';
 import { pollJobStatus } from '../../shared/job-polling.js';
+import { escapeHtml } from '../../shared/dom.js';
 import { pickServerFile, prefersServerPicker } from './server-picker.js';
 
 export function initBiometrics(elements) {
@@ -161,7 +162,7 @@ export function initBiometrics(elements) {
 
             const options = ['<option value="">Auto-detect from file columns</option>'];
             columns.forEach((column) => {
-                options.push(`<option value="${escapeHtmlForOption(column)}">${escapeHtmlForOption(column)}</option>`);
+                options.push(`<option value="${escapeHtml(column)}">${escapeHtml(column)}</option>`);
             });
             biometricsIdColumn.innerHTML = options.join('');
 
@@ -177,7 +178,7 @@ export function initBiometrics(elements) {
             }
             if (biometricsIdColumnHelp) {
                 biometricsIdColumnHelp.innerHTML = suggested
-                    ? `<i class="fas fa-check-circle me-1 text-success"></i>Suggested: <strong>${escapeHtmlForOption(suggested)}</strong>`
+                    ? `<i class="fas fa-check-circle me-1 text-success"></i>Suggested: <strong>${escapeHtml(suggested)}</strong>`
                     : '<i class="fas fa-exclamation-triangle me-1 text-warning"></i>No participant ID column found. Please select it manually.';
             }
         } catch (error) {
@@ -190,17 +191,9 @@ export function initBiometrics(elements) {
                 biometricsIdColumnStatus.className = 'ms-2 small text-danger';
             }
             if (biometricsIdColumnHelp) {
-                biometricsIdColumnHelp.innerHTML = `<i class="fas fa-exclamation-triangle me-1 text-danger"></i>${escapeHtmlForOption(error.message || 'Failed to detect columns')}`;
+                biometricsIdColumnHelp.innerHTML = `<i class="fas fa-exclamation-triangle me-1 text-danger"></i>${escapeHtml(error.message || 'Failed to detect columns')}`;
             }
         }
-    }
-
-    function escapeHtmlForOption(value) {
-        return String(value)
-            .replace(/&/g, '&amp;')
-            .replace(/</g, '&lt;')
-            .replace(/>/g, '&gt;')
-            .replace(/"/g, '&quot;');
     }
 
     function getBiometricsIdColumnValue() {

--- a/app/static/js/modules/converter/environment.js
+++ b/app/static/js/modules/converter/environment.js
@@ -670,7 +670,7 @@ export function initEnvironment(elements) {
                 abortErrorMessage: 'Environment polling aborted due to project change.',
                 timeoutErrorMessage: 'Environment conversion status timed out after 5 minutes. Please check conversion logs and retry.',
                 statusFailureMessage: 'Failed to retrieve environment conversion status after multiple attempts.',
-                getFailureError: (nextStatusData) => nextStatusData.error || 'Environment conversion failed',
+                failureMessage: 'Environment conversion failed',
             });
 
             updateProgressUI(100);
@@ -1139,7 +1139,7 @@ export function initEnvironment(elements) {
                     abortErrorMessage: 'Environment polling aborted due to project change.',
                     timeoutErrorMessage: 'Environment conversion status timed out after 5 minutes. Please check conversion logs and retry.',
                     statusFailureMessage: 'Failed to retrieve environment conversion status after multiple attempts.',
-                    getFailureError: (nextStatusData) => nextStatusData.error || 'Environment conversion failed',
+                    failureMessage: 'Environment conversion failed',
                 });
 
                 if (!pilotMode) {

--- a/app/static/js/modules/converter/eyetracking.js
+++ b/app/static/js/modules/converter/eyetracking.js
@@ -478,7 +478,7 @@ export function initEyetracking(elements) {
                     abortErrorMessage: 'Eyetracking polling aborted due to project change.',
                     timeoutErrorMessage: 'Eyetracking conversion status timed out after 5 minutes. Please review logs and retry.',
                     statusFailureMessage: 'Failed to retrieve conversion status after multiple attempts.',
-                    getFailureError: (nextStatusData) => nextStatusData.error || 'Batch conversion failed',
+                    failureMessage: 'Batch conversion failed',
                 });
 
                 const result = statusData.result || {};

--- a/app/static/js/modules/converter/participants.js
+++ b/app/static/js/modules/converter/participants.js
@@ -3144,7 +3144,7 @@ export function initParticipants() {
                 abortErrorMessage: 'Participants polling aborted due to project change.',
                 timeoutErrorMessage: 'Participants conversion status timed out. Please review logs and retry.',
                 statusFailureMessage: 'Failed to retrieve conversion status after multiple attempts.',
-                getFailureError: (status) => status.error || 'Conversion failed',
+                failureMessage: 'Conversion failed',
             });
             return statusData.result || {};
         } finally {

--- a/app/static/js/modules/converter/physio.js
+++ b/app/static/js/modules/converter/physio.js
@@ -663,7 +663,7 @@ export function initPhysio(elements) {
                     abortErrorMessage: 'Physio polling aborted due to project change.',
                     timeoutErrorMessage: 'Physio conversion status timed out after 5 minutes. Please review logs and retry.',
                     statusFailureMessage: 'Failed to retrieve conversion status after multiple attempts.',
-                    getFailureError: (nextStatusData) => nextStatusData.error || 'Batch conversion failed',
+                    failureMessage: 'Batch conversion failed',
                 });
 
                 const result = statusData.result || {};

--- a/app/static/js/modules/converter/survey-convert.js
+++ b/app/static/js/modules/converter/survey-convert.js
@@ -7,6 +7,7 @@
 import { fetchWithApiFallback } from '../../shared/api.js';
 import { resolveCurrentProjectPath } from '../../shared/project-state.js';
 import { createSessionRegistrar } from '../../shared/session-register.js';
+import { escapeHtml } from '../../shared/dom.js';
 import { createSurveyParticipantsMetadataController } from './survey-participants-metadata.js';
 import { createSurveyWorkflowPrepareController } from './survey-workflow-prepare.js';
 import { createSurveyWorkflowConvertController } from './survey-workflow-convert.js';
@@ -1983,16 +1984,6 @@ export function initSurveyConvert(elements) {
         convertInfo,
         appendLog,
     });
-
-    function escapeHtml(text) {
-        if (text === null || text === undefined) return '';
-        return String(text)
-            .replace(/&/g, '&amp;')
-            .replace(/</g, '&lt;')
-            .replace(/>/g, '&gt;')
-            .replace(/"/g, '&quot;')
-            .replace(/'/g, '&#39;');
-    }
 
     const participantsMetadataController = createSurveyParticipantsMetadataController({
         escapeHtml,

--- a/app/static/js/modules/converter/survey-workflow-convert.js
+++ b/app/static/js/modules/converter/survey-workflow-convert.js
@@ -331,7 +331,7 @@ export function createSurveyWorkflowConvertController({
                 abortErrorMessage: 'Conversion canceled by user.',
                 timeoutErrorMessage: 'Survey conversion status timed out. Please review logs and retry.',
                 statusFailureMessage: 'Failed to retrieve conversion status after multiple attempts.',
-                getFailureError: (status) => status.error || 'Conversion failed',
+                failureMessage: 'Conversion failed',
             });
 
             advanceSurveyRunProgress('convert', 68, 'Applying conversion output and validation details...');

--- a/app/static/js/shared/job-polling.js
+++ b/app/static/js/shared/job-polling.js
@@ -18,11 +18,7 @@
  * @param {string} [options.abortErrorMessage='Polling aborted.']
  * @param {string} [options.timeoutErrorMessage='Job status timed out.']
  * @param {string} [options.statusFailureMessage='Failed to retrieve job status after multiple attempts.']
- * @param {(status:Object)=>Array} [options.getLogs]
- * @param {(status:Object,cursor:number,logs:Array)=>number} [options.getNextCursor]
- * @param {(status:Object)=>boolean} [options.isDone]
- * @param {(status:Object)=>boolean} [options.isSuccess]
- * @param {(status:Object)=>string} [options.getFailureError]
+ * @param {string} [options.failureMessage='Job failed.'] - Fallback used when the final status has no `.error` field.
  * @returns {Promise<Object>} Final successful status payload.
  */
 export async function pollJobStatus(options) {
@@ -80,16 +76,18 @@ export async function pollJobStatus(options) {
         abortErrorMessage = 'Polling aborted.',
         timeoutErrorMessage = 'Job status timed out.',
         statusFailureMessage = 'Failed to retrieve job status after multiple attempts.',
-        getLogs = (status) => (Array.isArray(status && status.logs) ? status.logs : []),
-        getNextCursor = (status, cursor, logs) => (
-            Number.isInteger(status && status.next_cursor)
-                ? status.next_cursor
-                : cursor + logs.length
-        ),
-        isDone = (status) => Boolean(status && status.done),
-        isSuccess = (status) => Boolean(status && status.success),
-        getFailureError = (status) => (status && status.error) || 'Job failed.',
+        failureMessage = 'Job failed.',
     } = options || {};
+
+    const getLogs = (status) => (Array.isArray(status && status.logs) ? status.logs : []);
+    const getNextCursor = (status, cursor, logs) => (
+        Number.isInteger(status && status.next_cursor)
+            ? status.next_cursor
+            : cursor + logs.length
+    );
+    const isDone = (status) => Boolean(status && status.done);
+    const isSuccess = (status) => Boolean(status && status.success);
+    const getFailureError = (status) => (status && status.error) || failureMessage;
 
     if (typeof fetchStatus !== 'function') {
         throw new Error('pollJobStatus requires a fetchStatus callback.');

--- a/src/converters/limesurvey.py
+++ b/src/converters/limesurvey.py
@@ -185,11 +185,9 @@ def parse_lsa_responses(lsa_path):
         title = row.find("title").text
         qid_to_title[qid] = title
 
-    text = xml_resp.decode("utf-8")
-    fieldnames = re.findall(r"<fieldname>(.*?)</fieldname>", text)
-
-    # Parse rows by XML to preserve order and decode CDATA
+    # Parse once; both the fieldname list and the row data come from this tree.
     resp_root = ET.fromstring(xml_resp)
+    fieldnames = [el.text or "" for el in resp_root.findall(".//fieldname")]
     rows = resp_root.findall("./responses/rows/row")
     records = []
     for row in rows:

--- a/src/converters/limesurvey.py
+++ b/src/converters/limesurvey.py
@@ -28,6 +28,20 @@ def _bootstrap_import_path() -> None:
             sys.path.insert(0, candidate_str)
 
 
+def _import_with_bootstrap(import_fn, *, catch=(ImportError,)):
+    """Run `import_fn`; on failure, add repo/app roots to sys.path and retry once.
+
+    If the retry also fails, the exception propagates to the caller — callers
+    that want a silent fallback (leaving names as their pre-declared default)
+    must wrap the call in their own try/except.
+    """
+    try:
+        return import_fn()
+    except catch:
+        _bootstrap_import_path()
+        return import_fn()
+
+
 # Import item registry for collision detection
 ItemRegistry: Any = None
 ItemCollisionError: Any = None
@@ -35,56 +49,58 @@ merge_survey_versions: Callable[..., Any] | None = None
 save_merged_template: Callable[..., Any] | None = None
 detect_version_name_from_import: Callable[..., Any] | None = None
 
-try:
+
+def _import_item_registry_and_merger():
     from src.converters.item_registry import (
-        ItemRegistry as _ItemRegistry,
-        ItemCollisionError as _ItemCollisionError,
+        ItemRegistry as item_registry_cls,
+        ItemCollisionError as item_collision_error_cls,
     )
     from src.converters.version_merger import (
-        merge_survey_versions as _merge_survey_versions,
-        save_merged_template as _save_merged_template,
-        detect_version_name_from_import as _detect_version_name_from_import,
+        merge_survey_versions as merge_survey_versions_fn,
+        save_merged_template as save_merged_template_fn,
+        detect_version_name_from_import as detect_version_name_from_import_fn,
     )
 
-    ItemRegistry = _ItemRegistry
-    ItemCollisionError = _ItemCollisionError
-    merge_survey_versions = _merge_survey_versions
-    save_merged_template = _save_merged_template
-    detect_version_name_from_import = _detect_version_name_from_import
-except ImportError:
-    _bootstrap_import_path()
-    try:
-        from src.converters.item_registry import (
-            ItemRegistry as _ItemRegistry,
-            ItemCollisionError as _ItemCollisionError,
-        )
-        from src.converters.version_merger import (
-            merge_survey_versions as _merge_survey_versions,
-            save_merged_template as _save_merged_template,
-            detect_version_name_from_import as _detect_version_name_from_import,
-        )
+    return (
+        item_registry_cls,
+        item_collision_error_cls,
+        merge_survey_versions_fn,
+        save_merged_template_fn,
+        detect_version_name_from_import_fn,
+    )
 
-        ItemRegistry = _ItemRegistry
-        ItemCollisionError = _ItemCollisionError
-        merge_survey_versions = _merge_survey_versions
-        save_merged_template = _save_merged_template
-        detect_version_name_from_import = _detect_version_name_from_import
-    except ImportError:
-        pass
 
 try:
-    from src.converters.survey_base import load_survey_library as load_schemas
-    from src.utils.naming import sanitize_task_name
-except (ImportError, ValueError):
-    _bootstrap_import_path()
-    from src.converters.survey_base import load_survey_library as load_schemas
+    (
+        ItemRegistry,
+        ItemCollisionError,
+        merge_survey_versions,
+        save_merged_template,
+        detect_version_name_from_import,
+    ) = _import_with_bootstrap(_import_item_registry_and_merger)
+except ImportError:
+    pass
+
+
+def _import_survey_base_and_naming():
+    from src.converters.survey_base import load_survey_library
     from src.utils.naming import sanitize_task_name
 
-try:
+    return load_survey_library, sanitize_task_name
+
+
+load_schemas, sanitize_task_name = _import_with_bootstrap(
+    _import_survey_base_and_naming, catch=(ImportError, ValueError)
+)
+
+
+def _import_csv_process_dataframe():
     from src.converters.csv import process_dataframe  # noqa: E402
-except ImportError:
-    _bootstrap_import_path()
-    from src.converters.csv import process_dataframe  # noqa: E402
+
+    return process_dataframe
+
+
+process_dataframe = _import_with_bootstrap(_import_csv_process_dataframe)
 
 # LimeSurvey question type codes mapped to human-readable names
 LIMESURVEY_QUESTION_TYPES = {

--- a/src/maintenance/_sync_library_keys.py
+++ b/src/maintenance/_sync_library_keys.py
@@ -1,0 +1,91 @@
+"""Shared key-synchronization logic for the survey/biometrics library maintenance scripts."""
+
+import json
+import os
+from pathlib import Path
+
+
+def _sync_library_keys(
+    library_dir,
+    *,
+    default_relative_path: tuple,
+    preferred_template_name: str,
+    reset_study_values: bool,
+    skip_item_prefix: bool,
+    mark_changed_for_skipped_keys: bool,
+) -> None:
+    if library_dir is None:
+        library_dir = Path(__file__).resolve().parent.parent.parent
+        for part in default_relative_path:
+            library_dir = library_dir / part
+    else:
+        library_dir = Path(library_dir)
+
+    if not library_dir.exists():
+        print(f"Error: Library directory {library_dir} does not exist.")
+        return
+
+    files = [f for f in os.listdir(library_dir) if f.endswith(".json")]
+    if not files:
+        print(f"No JSON files found in {library_dir}")
+        return
+
+    template_file = preferred_template_name if preferred_template_name in files else files[0]
+
+    with open(os.path.join(library_dir, template_file), "r") as f:
+        template = json.load(f)
+
+    template_keys = set(template.keys())
+    template_study_keys = set(template.get("Study", {}).keys())
+    template_tech_keys = set(template.get("Technical", {}).keys())
+
+    for filename in files:
+        if filename == template_file:
+            continue
+
+        filepath = os.path.join(library_dir, filename)
+        with open(filepath, "r") as f:
+            data = json.load(f)
+
+        changed = False
+
+        # Check top level
+        for k in template_keys:
+            if skip_item_prefix and k.startswith("item_"):
+                continue
+            if k not in data:
+                if k in ["Technical", "Study", "I18n", "Metadata", "Scoring", "Normative"]:
+                    data[k] = template[k].copy()
+                    if reset_study_values and k == "Study":
+                        for sk in data[k]:
+                            data[k][sk] = ""
+                    changed = True
+                elif mark_changed_for_skipped_keys:
+                    # Not a recognized block (e.g. a per-item top-level key like
+                    # "AAI01" that isn't `item_`-prefixed) — nothing is copied,
+                    # but the survey variant still flags the file as touched so
+                    # it gets rewritten. Preserves original sync_survey_keys.py
+                    # behavior; sync_biometrics_keys.py never set this flag here.
+                    changed = True
+                # else: likely an item or something else, skip
+
+        # Check Study
+        if "Study" in data:
+            for k in template_study_keys:
+                if k not in data["Study"]:
+                    data["Study"][k] = ""
+                    changed = True
+
+        # Check Technical
+        if "Technical" in data:
+            for k in template_tech_keys:
+                if k not in data["Technical"]:
+                    data["Technical"][k] = ""
+                    changed = True
+
+        if changed:
+            with open(filepath, "w") as f:
+                json.dump(data, f, indent=2)
+            print(f"✅ Synchronized keys for {filename}")
+        else:
+            print(f"ℹ️ {filename} is already synchronized")

--- a/src/maintenance/sync_biometrics_keys.py
+++ b/src/maintenance/sync_biometrics_keys.py
@@ -1,82 +1,15 @@
-import json
-import os
-from pathlib import Path
+from ._sync_library_keys import _sync_library_keys
 
 
 def sync_biometrics_keys(library_dir=None):
-    if library_dir is None:
-        library_dir = (
-            Path(__file__).resolve().parent.parent.parent / "library" / "biometrics"
-        )
-    else:
-        library_dir = Path(library_dir)
-
-    if not library_dir.exists():
-        print(f"Error: Library directory {library_dir} does not exist.")
-        return
-
-    files = [f for f in os.listdir(library_dir) if f.endswith(".json")]
-    if not files:
-        print(f"No JSON files found in {library_dir}")
-        return
-
-    # Use cmj as template if it exists, else first file
-    template_file = (
-        "biometrics-cmj.json" if "biometrics-cmj.json" in files else files[0]
+    _sync_library_keys(
+        library_dir,
+        default_relative_path=("library", "biometrics"),
+        preferred_template_name="biometrics-cmj.json",
+        reset_study_values=False,
+        skip_item_prefix=False,
+        mark_changed_for_skipped_keys=False,
     )
-
-    with open(os.path.join(library_dir, template_file), "r") as f:
-        template = json.load(f)
-
-    template_keys = set(template.keys())
-    template_study_keys = set(template.get("Study", {}).keys())
-    template_tech_keys = set(template.get("Technical", {}).keys())
-
-    for filename in files:
-        if filename == template_file:
-            continue
-
-        filepath = os.path.join(library_dir, filename)
-        with open(filepath, "r") as f:
-            data = json.load(f)
-
-        changed = False
-
-        # Check top level
-        for k in template_keys:
-            if k not in data:
-                if k in [
-                    "Technical",
-                    "Study",
-                    "I18n",
-                    "Metadata",
-                    "Scoring",
-                    "Normative",
-                ]:
-                    data[k] = template[k].copy()
-                    changed = True
-                # DO NOT copy measurement keys (like pre_cmj_1) to other tasks!
-
-        # Check Study
-        if "Study" in data:
-            for k in template_study_keys:
-                if k not in data["Study"]:
-                    data["Study"][k] = ""
-                    changed = True
-
-        # Check Technical
-        if "Technical" in data:
-            for k in template_tech_keys:
-                if k not in data["Technical"]:
-                    data["Technical"][k] = ""
-                    changed = True
-
-        if changed:
-            with open(filepath, "w") as f:
-                json.dump(data, f, indent=2)
-            print(f"✅ Synchronized keys for {filename}")
-        else:
-            print(f"ℹ️ {filename} is already synchronized")
 
 
 if __name__ == "__main__":

--- a/src/maintenance/sync_survey_keys.py
+++ b/src/maintenance/sync_survey_keys.py
@@ -1,87 +1,15 @@
-import json
-import os
-from pathlib import Path
+from ._sync_library_keys import _sync_library_keys
 
 
 def sync_survey_keys(library_dir=None):
-    if library_dir is None:
-        # Default to project library
-        library_dir = (
-            Path(__file__).resolve().parent.parent.parent / "library" / "survey"
-        )
-    else:
-        library_dir = Path(library_dir)
-
-    if not library_dir.exists():
-        print(f"Error: Library directory {library_dir} does not exist.")
-        return
-
-    files = [f for f in os.listdir(library_dir) if f.endswith(".json")]
-    if not files:
-        print(f"No JSON files found in {library_dir}")
-        return
-
-    # Use bdi as template if it exists, else first file
-    template_file = "survey-bdi.json" if "survey-bdi.json" in files else files[0]
-
-    with open(os.path.join(library_dir, template_file), "r") as f:
-        template = json.load(f)
-
-    template_keys = set(template.keys())
-    template_study_keys = set(template.get("Study", {}).keys())
-    template_tech_keys = set(template.get("Technical", {}).keys())
-
-    for filename in files:
-        if filename == template_file:
-            continue
-
-        filepath = os.path.join(library_dir, filename)
-        with open(filepath, "r") as f:
-            data = json.load(f)
-
-        changed = False
-
-        # Check top level
-        for k in template_keys:
-            if k not in data and not k.startswith("item_"):  # Don't copy items
-                if k in [
-                    "Technical",
-                    "Study",
-                    "I18n",
-                    "Metadata",
-                    "Scoring",
-                    "Normative",
-                ]:
-                    data[k] = template[k].copy()
-                    # Reset specific values
-                    if k == "Study":
-                        for sk in data[k]:
-                            data[k][sk] = ""
-                else:
-                    # It's likely an item or something else, skip
-                    pass
-                changed = True
-
-        # Check Study
-        if "Study" in data:
-            for k in template_study_keys:
-                if k not in data["Study"]:
-                    data["Study"][k] = ""
-                    changed = True
-
-        # Check Technical
-        if "Technical" in data:
-            for k in template_tech_keys:
-                if k not in data["Technical"]:
-                    data["Technical"][k] = ""
-                    changed = True
-
-        if changed:
-            with open(filepath, "w") as f:
-                json.dump(data, f, indent=2)
-            print(f"✅ Synchronized keys for {filename}")
-        else:
-            print(f"ℹ️ {filename} is already synchronized")
+    _sync_library_keys(
+        library_dir,
+        default_relative_path=("library", "survey"),
+        preferred_template_name="survey-bdi.json",
+        reset_study_values=True,
+        skip_item_prefix=True,
+        mark_changed_for_skipped_keys=True,
+    )
 
 
 if __name__ == "__main__":

--- a/src/runtime_dependencies.py
+++ b/src/runtime_dependencies.py
@@ -7,134 +7,118 @@ from pathlib import Path
 from typing import Any
 
 
-def inspect_pyreadstat_write_support(
-    bundle_root: str | Path | None = None,
+def _inspect_module_support(
+    module_name: str,
+    bundle_root: str | Path | None,
+    *,
+    write_attr: str,
+    version_attrs: tuple[str, ...],
+    keys: dict[str, str],
 ) -> dict[str, Any]:
-    """Describe whether pyreadstat is importable and exposes SPSS write support."""
+    """Describe whether `module_name` is importable and exposes `write_attr`.
+
+    `keys` maps the generic internal field names (importable, write_support,
+    namespace_bundle_stub, module_file, module_path, available_attrs,
+    bundle_entries, error) to the actual output dict key names, since
+    `inspect_pyreadstat_write_support` and `inspect_pandas_support` use
+    different (and only partially symmetric) key-prefixing conventions so
+    their results can be dict-merged into one payload without colliding.
+    """
 
     bundle_entries: list[str] = []
     normalized_bundle_root: Path | None = None
     if bundle_root is not None:
         normalized_bundle_root = Path(bundle_root).resolve()
         bundle_entries = sorted(
-            path.name for path in normalized_bundle_root.glob("pyreadstat*")
+            path.name for path in normalized_bundle_root.glob(f"{module_name}*")
         )
 
     try:
-        pyreadstat_module = importlib.import_module("pyreadstat")
+        module = importlib.import_module(module_name)
     except ModuleNotFoundError as exc:
         return {
-            "pyreadstat_importable": False,
-            "pyreadstat_write_support": False,
-            "namespace_bundle_stub": False,
-            "module_file": None,
-            "module_path": [],
-            "available_attrs": [],
-            "bundle_entries": bundle_entries,
-            "error": f"{type(exc).__name__}: {exc}",
+            keys["importable"]: False,
+            keys["write_support"]: False,
+            keys["namespace_bundle_stub"]: False,
+            keys["module_file"]: None,
+            keys["module_path"]: [],
+            keys["available_attrs"]: [],
+            keys["bundle_entries"]: bundle_entries,
+            keys["error"]: f"{type(exc).__name__}: {exc}",
         }
     except Exception as exc:
         return {
-            "pyreadstat_importable": False,
-            "pyreadstat_write_support": False,
-            "namespace_bundle_stub": False,
-            "module_file": None,
-            "module_path": [],
-            "available_attrs": [],
-            "bundle_entries": bundle_entries,
-            "error": f"{type(exc).__name__}: {exc}",
+            keys["importable"]: False,
+            keys["write_support"]: False,
+            keys["namespace_bundle_stub"]: False,
+            keys["module_file"]: None,
+            keys["module_path"]: [],
+            keys["available_attrs"]: [],
+            keys["bundle_entries"]: bundle_entries,
+            keys["error"]: f"{type(exc).__name__}: {exc}",
         }
 
-    module_file = getattr(pyreadstat_module, "__file__", None)
-    module_path = [
-        str(Path(path).resolve()) for path in getattr(pyreadstat_module, "__path__", [])
-    ]
-    available_attrs = [
-        name
-        for name in ("__version__", "read_sav", "write_sav", "read_dta", "write_dta")
-        if hasattr(pyreadstat_module, name)
-    ]
+    module_file = getattr(module, "__file__", None)
+    module_path = [str(Path(path).resolve()) for path in getattr(module, "__path__", [])]
+    available_attrs = [name for name in version_attrs if hasattr(module, name)]
 
     namespace_bundle_stub = False
     if normalized_bundle_root is not None and bundle_entries:
-        bundled_namespace_path = str((normalized_bundle_root / "pyreadstat").resolve())
-        namespace_bundle_stub = (
-            module_file is None and bundled_namespace_path in module_path
-        )
+        bundled_namespace_path = str((normalized_bundle_root / module_name).resolve())
+        namespace_bundle_stub = module_file is None and bundled_namespace_path in module_path
 
     return {
-        "pyreadstat_importable": True,
-        "pyreadstat_write_support": hasattr(pyreadstat_module, "write_sav"),
-        "namespace_bundle_stub": namespace_bundle_stub,
-        "module_file": module_file,
-        "module_path": module_path,
-        "available_attrs": available_attrs,
-        "bundle_entries": bundle_entries,
-        "error": None,
+        keys["importable"]: True,
+        keys["write_support"]: hasattr(module, write_attr),
+        keys["namespace_bundle_stub"]: namespace_bundle_stub,
+        keys["module_file"]: module_file,
+        keys["module_path"]: module_path,
+        keys["available_attrs"]: available_attrs,
+        keys["bundle_entries"]: bundle_entries,
+        keys["error"]: None,
     }
+
+
+def inspect_pyreadstat_write_support(
+    bundle_root: str | Path | None = None,
+) -> dict[str, Any]:
+    """Describe whether pyreadstat is importable and exposes SPSS write support."""
+    return _inspect_module_support(
+        "pyreadstat",
+        bundle_root,
+        write_attr="write_sav",
+        version_attrs=("__version__", "read_sav", "write_sav", "read_dta", "write_dta"),
+        keys={
+            "importable": "pyreadstat_importable",
+            "write_support": "pyreadstat_write_support",
+            "namespace_bundle_stub": "namespace_bundle_stub",
+            "module_file": "module_file",
+            "module_path": "module_path",
+            "available_attrs": "available_attrs",
+            "bundle_entries": "bundle_entries",
+            "error": "error",
+        },
+    )
 
 
 def inspect_pandas_support(bundle_root: str | Path | None = None) -> dict[str, Any]:
     """Describe whether pandas is importable and exposes core dataframe APIs."""
-
-    bundle_entries: list[str] = []
-    normalized_bundle_root: Path | None = None
-    if bundle_root is not None:
-        normalized_bundle_root = Path(bundle_root).resolve()
-        bundle_entries = sorted(path.name for path in normalized_bundle_root.glob("pandas*"))
-
-    try:
-        pandas_module = importlib.import_module("pandas")
-    except ModuleNotFoundError as exc:
-        return {
-            "pandas_importable": False,
-            "pandas_dataframe_support": False,
-            "pandas_namespace_bundle_stub": False,
-            "pandas_module_file": None,
-            "pandas_module_path": [],
-            "pandas_available_attrs": [],
-            "pandas_bundle_entries": bundle_entries,
-            "pandas_error": f"{type(exc).__name__}: {exc}",
-        }
-    except Exception as exc:
-        return {
-            "pandas_importable": False,
-            "pandas_dataframe_support": False,
-            "pandas_namespace_bundle_stub": False,
-            "pandas_module_file": None,
-            "pandas_module_path": [],
-            "pandas_available_attrs": [],
-            "pandas_bundle_entries": bundle_entries,
-            "pandas_error": f"{type(exc).__name__}: {exc}",
-        }
-
-    module_file = getattr(pandas_module, "__file__", None)
-    module_path = [
-        str(Path(path).resolve()) for path in getattr(pandas_module, "__path__", [])
-    ]
-    available_attrs = [
-        name
-        for name in ("__version__", "DataFrame", "Series", "read_csv")
-        if hasattr(pandas_module, name)
-    ]
-
-    namespace_bundle_stub = False
-    if normalized_bundle_root is not None and bundle_entries:
-        bundled_namespace_path = str((normalized_bundle_root / "pandas").resolve())
-        namespace_bundle_stub = (
-            module_file is None and bundled_namespace_path in module_path
-        )
-
-    return {
-        "pandas_importable": True,
-        "pandas_dataframe_support": hasattr(pandas_module, "DataFrame"),
-        "pandas_namespace_bundle_stub": namespace_bundle_stub,
-        "pandas_module_file": module_file,
-        "pandas_module_path": module_path,
-        "pandas_available_attrs": available_attrs,
-        "pandas_bundle_entries": bundle_entries,
-        "pandas_error": None,
-    }
+    return _inspect_module_support(
+        "pandas",
+        bundle_root,
+        write_attr="DataFrame",
+        version_attrs=("__version__", "DataFrame", "Series", "read_csv"),
+        keys={
+            "importable": "pandas_importable",
+            "write_support": "pandas_dataframe_support",
+            "namespace_bundle_stub": "pandas_namespace_bundle_stub",
+            "module_file": "pandas_module_file",
+            "module_path": "pandas_module_path",
+            "available_attrs": "pandas_available_attrs",
+            "bundle_entries": "pandas_bundle_entries",
+            "error": "pandas_error",
+        },
+    )
 
 
 def has_pyreadstat_write_support() -> bool:


### PR DESCRIPTION
## Summary

Two-pass repo-wide over-engineering audit (`PONYTAIL-AUDIT.md`), applied as 14 commits. Since `origin/main` doesn't yet have pass 1's commit, this PR bundles both passes together.

**Pass 1** — dead code, duplicate helpers, stdlib swaps:
- Deleted dead backward-compat aliases and optional-import shims in `conversion.py`
- Cleaned unused imports/locals across ~15 web blueprint files
- Deleted unused `ItemRegistry` methods, `text_sanitizer` functions, and the redundant `sanitize_question_text` wrapper
- Deduped `_extract_terminal_suffix_label` between `mri_json_scrubber.py` and `project_export_helpers.py`
- Swapped hand-rolled file-compare/UUID/deep-clone for `filecmp.cmp`, `crypto.randomUUID()`, `structuredClone()`
- Consolidated 4 duplicated `read_json`/`write_json` helpers onto the canonical `src/utils/io.py` versions
- Added a `_curl_json_post` helper for the 3 `backend_monitoring.py` functions sharing the same curl-JSON-POST shape
- Converted `anc_export.py`'s hand-rolled CITATION.cff YAML builder to `yaml.safe_dump`

**Pass 2** — remaining dedups and shrinks, executed via a subagent-driven implementation plan (`docs/superpowers/plans/2026-08-09-ponytail-audit-pass2-remaining-fixes.md`) with a fresh implementer + independent reviewer per task:
- Deduped `_sanitize_answer_code_for_ls`, `sanitize_id`, and 3 divergent `_normalize_run_entity` copies onto single canonical implementations
- Consolidated `_deep_merge` (2 copies → 1), `sync_survey_keys`/`sync_biometrics_keys` (→ shared helper), `inspect_pyreadstat_write_support`/`inspect_pandas_support` (→ shared helper), and the 3 import-bootstrap-retry blocks in `limesurvey.py`
- Removed a redundant regex XML parse in `limesurvey.py`
- Dropped `pollJobStatus`'s 4 never-overridden JS hooks, replaced a callback with a plain string option
- Consolidated `escapeHtml` duplicates onto the canonical `shared/dom.js` export
- Shrank `_create_bidsignore`'s chained string concatenation to a list + join
- Along the way, fixed one genuine pre-existing bug uncovered while completing a dedup: an off-by-one in `app/src/_compat.py::load_canonical_module`'s `repo_root` computation for nested `canonical_rel_path` values (verified load-bearing in both dev and frozen-bundle runtimes)

Every pass-2 task was independently task-reviewed (spec compliance + code quality), and the whole branch got a final independent review — verdict: ready to merge, zero Critical/Important findings. Full task-by-task history, deviations, and deferred-minor findings are documented in the plan file and this PR's commit messages.

## Test plan

- [x] Full suite: `python3 -m pytest tests/ -q` → 3453 passed, 3 skipped, same 4 pre-existing baseline failures (confirmed unrelated to this work, both on clean `main` and after every commit in this branch)
- [x] `ruff --select F401,F841` clean on every touched Python file (pre-existing unrelated findings left alone, documented)
- [x] `node --check` clean on every touched JS file
- [x] Dual-tree liveness (`src/` vs `app/src/`) verified per-file before every edit, per this repo's documented drift hazard

🤖 Generated with [Claude Code](https://claude.com/claude-code)