### PR TITLE
docs: exclude superpowers plan files from Sphinx build

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -26,6 +26,8 @@ exclude_patterns = [
     ".DS_Store",
     "README.md",
     "archive/**",
+    # Internal planning docs (superpowers skill working files), not user docs.
+    "superpowers/**",
     # Advanced pages intentionally hidden from public RTD navigation.
     "LIMESURVEY_VERSION_DIFFERENCES.md",
     "PAVLOVIA_EXPORT.md",


### PR DESCRIPTION
## Summary
- `docs/superpowers/plans/2026-08-09-ponytail-audit-pass2-remaining-fixes.md` is an internal working file from the superpowers skill (subagent-driven-development plan), not published documentation.
- Sphinx picked it up anyway, producing a "not in any toctree" warning plus two JS-highlighting warnings on JSDoc code blocks inside it. CI builds docs with `-W` (warnings-as-errors), so the build failed: https://github.com/MRI-Lab-Graz/prism-studio/actions/runs/31330486565/job/93287834672
- Added `superpowers/**` to `exclude_patterns` in `docs/conf.py`, following the existing pattern used for `archive/**` and other intentionally-hidden pages.

## Test plan
- [x] `sphinx-build -b html docs docs/_build/html -W` succeeds locally with zero warnings
- [ ] CI "Docs Build" job passes on this PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)