### PR TITLE
dedup: consolidate prefersServerPicker and getProgressEls/setStatusBadge

### DIFF
--- a/app/static/js/file_management.js
+++ b/app/static/js/file_management.js
@@ -32,6 +32,26 @@ document.addEventListener('DOMContentLoaded', () => {
         return sharedFetchWithApiFallback(url, options, fallbackMessage);
     }
 
+    const sharedPathPickerModuleUrl = new URL('./shared/path-picker.js', fileManagementScriptUrl).href;
+    let sharedPrefersServerPickerPromise = null;
+
+    function loadSharedPrefersServerPicker() {
+        if (!sharedPrefersServerPickerPromise) {
+            sharedPrefersServerPickerPromise = import(sharedPathPickerModuleUrl).then(({ prefersServerPicker }) => {
+                if (typeof prefersServerPicker !== 'function') {
+                    throw new Error('Shared path picker helper is unavailable.');
+                }
+                return prefersServerPicker;
+            });
+        }
+        return sharedPrefersServerPickerPromise;
+    }
+
+    async function prefersServerPicker() {
+        const sharedPrefersServerPicker = await loadSharedPrefersServerPicker();
+        return sharedPrefersServerPicker();
+    }
+
     function getCurrentProjectPath() {
         if (typeof window.resolveCurrentProjectPath === 'function') {
             return String(window.resolveCurrentProjectPath() || '').trim();
@@ -211,11 +231,6 @@ document.addEventListener('DOMContentLoaded', () => {
         return window.PrismPathPicker || null;
     }
 
-    function prefersServerPicker() {
-        const pathPicker = getPathPicker();
-        return Boolean(pathPicker && typeof pathPicker.prefersServerPicker === 'function' && pathPicker.prefersServerPicker());
-    }
-
     async function pickServerFolder(options = {}) {
         const pathPicker = getPathPicker();
         if (!(pathPicker && typeof pathPicker.pickServerFolder === 'function')) {
@@ -234,8 +249,8 @@ document.addEventListener('DOMContentLoaded', () => {
         return pathPicker.pickServerFile(options);
     }
 
-    function applyRemotePickerUiState() {
-        const connectedToServer = prefersServerPicker();
+    async function applyRemotePickerUiState() {
+        const connectedToServer = await prefersServerPicker();
 
         const renamerInput = document.getElementById('renamerFiles');
         const renamerLocalUploadGroup = document.getElementById('renamerLocalUploadGroup');

--- a/app/static/js/index.js
+++ b/app/static/js/index.js
@@ -24,6 +24,26 @@ document.addEventListener('DOMContentLoaded', function() {
         return sharedFetchWithRelativePathFallback(url, options, fallbackMessage);
     }
 
+    const sharedPathPickerModuleUrl = new URL('./shared/path-picker.js', validatorScriptUrl).href;
+    let sharedPrefersServerPickerPromise = null;
+
+    function loadSharedPrefersServerPicker() {
+        if (!sharedPrefersServerPickerPromise) {
+            sharedPrefersServerPickerPromise = import(sharedPathPickerModuleUrl).then(({ prefersServerPicker }) => {
+                if (typeof prefersServerPicker !== 'function') {
+                    throw new Error('Shared path picker helper is unavailable.');
+                }
+                return prefersServerPicker;
+            });
+        }
+        return sharedPrefersServerPickerPromise;
+    }
+
+    async function prefersServerPicker() {
+        const sharedPrefersServerPicker = await loadSharedPrefersServerPicker();
+        return sharedPrefersServerPicker();
+    }
+
     // Validation Mode Toggles
     const modeRadios = document.querySelectorAll('input[name="validation_mode"]');
     const bidsOptions = document.getElementById('bids_options');
@@ -167,11 +187,6 @@ document.addEventListener('DOMContentLoaded', function() {
 
     function getPathPicker() {
         return window.PrismPathPicker || null;
-    }
-
-    function prefersServerPicker() {
-        const pathPicker = getPathPicker();
-        return Boolean(pathPicker && typeof pathPicker.prefersServerPicker === 'function' && pathPicker.prefersServerPicker());
     }
 
     async function browseFolder(options = {}) {
@@ -992,8 +1007,8 @@ document.addEventListener('DOMContentLoaded', function() {
         }
     }
 
-    function applyRemotePickerUiState() {
-        const connectedToServer = prefersServerPicker();
+    async function applyRemotePickerUiState() {
+        const connectedToServer = await prefersServerPicker();
 
         if (folderBtn) {
             folderBtn.innerHTML = '<i class="fas fa-folder-open me-2"></i>Browse Folder';
@@ -1110,8 +1125,11 @@ document.addEventListener('DOMContentLoaded', function() {
     if (browseLibraryBtn && libraryPathInput) {
         browseLibraryBtn.addEventListener('click', async function() {
             try {
+                const title = (await prefersServerPicker())
+                    ? 'Select Template Library Root on Server'
+                    : 'Select Template Library Root';
                 const pickedPath = await browseFolder({
-                    title: prefersServerPicker() ? 'Select Template Library Root on Server' : 'Select Template Library Root',
+                    title,
                     confirmLabel: 'Use This Folder',
                     startPath: (libraryPathInput.value || '').trim()
                 });

--- a/app/static/js/modules/converter/server-picker.js
+++ b/app/static/js/modules/converter/server-picker.js
@@ -1,14 +1,9 @@
+import { prefersServerPicker } from '../../shared/path-picker.js';
+
+export { prefersServerPicker };
+
 function getPathPicker() {
     return typeof window !== 'undefined' ? window.PrismPathPicker : null;
-}
-
-export function prefersServerPicker() {
-    const pathPicker = getPathPicker();
-    return Boolean(
-        pathPicker
-        && typeof pathPicker.prefersServerPicker === 'function'
-        && pathPicker.prefersServerPicker()
-    );
 }
 
 export async function pickServerFile(options) {

--- a/app/static/js/modules/converter/server-picker.test.js
+++ b/app/static/js/modules/converter/server-picker.test.js
@@ -1,0 +1,24 @@
+import { afterEach, describe, expect, it } from 'vitest';
+
+import { prefersServerPicker } from './server-picker.js';
+
+describe('server-picker prefersServerPicker', () => {
+  afterEach(() => {
+    delete globalThis.window;
+  });
+
+  it('delegates to PrismPathPicker.prefersServerPicker when available', () => {
+    globalThis.window = { PrismPathPicker: { prefersServerPicker: () => true } };
+    expect(prefersServerPicker()).toBe(true);
+  });
+
+  it('falls back to PrismFileSystemMode.prefersServerPicker when PrismPathPicker is unavailable', () => {
+    globalThis.window = { PrismFileSystemMode: { prefersServerPicker: () => true } };
+    expect(prefersServerPicker()).toBe(true);
+  });
+
+  it('returns false when neither picker is available', () => {
+    globalThis.window = {};
+    expect(prefersServerPicker()).toBe(false);
+  });
+});

--- a/app/static/js/modules/projects/datalad_server.js
+++ b/app/static/js/modules/projects/datalad_server.js
@@ -10,33 +10,21 @@
  *   local sibling registration. Local files are always kept.
  */
 
-import { setButtonLoading } from './helpers.js';
+import { getProgressEls, setButtonLoading, setStatusBadge as setStatusBadgeFor } from './helpers.js';
 import { getById, setHtml, hide, show, escapeHtml } from '../../shared/dom.js';
 import { fetchWithApiFallback } from '../../shared/api.js';
 import { resolveCurrentProjectPath } from '../../shared/project-state.js';
 import { openRemoteFolderPicker } from './remote_folder_picker.js';
 import { isRiaUrl } from '../../shared/ssh-target.js';
 
+const PROGRESS_PREFIX = 'dataladServer';
+
 let dataladServerModuleInitialized = false;
 let activeJobId = null;
 let activeJobCancelled = false;
 
-function getProgressEls() {
-    return {
-        progressDiv: getById('dataladServerProgress'),
-        progressBar: getById('dataladServerProgressBar'),
-        progressText: getById('dataladServerProgressText'),
-        statusText: getById('dataladServerStatusText'),
-        resultDiv: getById('dataladServerResult'),
-        cancelBtn: getById('dataladServerCancelBtn'),
-    };
-}
-
 function setStatusBadge(text, tone = 'secondary') {
-    const badge = getById('dataladServerStatusBadge');
-    if (!badge) return;
-    badge.className = `badge bg-${tone}`;
-    badge.textContent = text;
+    setStatusBadgeFor(PROGRESS_PREFIX, text, tone);
 }
 
 /**
@@ -110,7 +98,7 @@ async function requestCancelForActiveJob(endpoint) {
 }
 
 async function runRiaJob({ startEndpoint, statusEndpointBase, button, originalText, requestData, successHeading }) {
-    const { progressDiv, progressBar, progressText, statusText, resultDiv, cancelBtn } = getProgressEls();
+    const { progressDiv, progressBar, progressText, statusText, resultDiv, cancelBtn } = getProgressEls(PROGRESS_PREFIX);
 
     activeJobCancelled = false;
     activeJobId = null;

--- a/app/static/js/modules/projects/helpers.js
+++ b/app/static/js/modules/projects/helpers.js
@@ -3,7 +3,36 @@
  * UI helper functions for button states, alerts, toasts, and feedback
  */
 
-import { escapeHtml } from '../../shared/dom.js';
+import { escapeHtml, getById } from '../../shared/dom.js';
+
+/**
+ * Look up the standard progress-panel elements for a server-sync section.
+ * @param {string} prefix - Element ID prefix (e.g. 'dataladServer', 'rsyncServer')
+ * @returns {{progressDiv, progressBar, progressText, statusText, resultDiv, cancelBtn}}
+ */
+export function getProgressEls(prefix) {
+    return {
+        progressDiv: getById(`${prefix}Progress`),
+        progressBar: getById(`${prefix}ProgressBar`),
+        progressText: getById(`${prefix}ProgressText`),
+        statusText: getById(`${prefix}StatusText`),
+        resultDiv: getById(`${prefix}Result`),
+        cancelBtn: getById(`${prefix}CancelBtn`),
+    };
+}
+
+/**
+ * Set a server-sync section's status badge tone and text.
+ * @param {string} prefix - Element ID prefix (e.g. 'dataladServer', 'rsyncServer')
+ * @param {string} text - Badge text
+ * @param {string} tone - Bootstrap badge tone (default 'secondary')
+ */
+export function setStatusBadge(prefix, text, tone = 'secondary') {
+    const badge = getById(`${prefix}StatusBadge`);
+    if (!badge) return;
+    badge.className = `badge bg-${tone}`;
+    badge.textContent = text;
+}
 
 /**
  * Set button loading state

--- a/app/static/js/modules/projects/helpers.test.js
+++ b/app/static/js/modules/projects/helpers.test.js
@@ -1,0 +1,74 @@
+import { afterEach, describe, expect, it } from 'vitest';
+
+import { getProgressEls, setStatusBadge } from './helpers.js';
+
+function stubDocument(elements) {
+  globalThis.document = {
+    getElementById: (id) => elements[id] || null,
+  };
+}
+
+describe('getProgressEls', () => {
+  afterEach(() => {
+    delete globalThis.document;
+  });
+
+  it('looks up progress elements by prefix', () => {
+    const els = {
+      dataladServerProgress: { id: 'progressDiv' },
+      dataladServerProgressBar: { id: 'progressBar' },
+      dataladServerProgressText: { id: 'progressText' },
+      dataladServerStatusText: { id: 'statusText' },
+      dataladServerResult: { id: 'resultDiv' },
+      dataladServerCancelBtn: { id: 'cancelBtn' },
+    };
+    stubDocument(els);
+
+    expect(getProgressEls('dataladServer')).toEqual({
+      progressDiv: els.dataladServerProgress,
+      progressBar: els.dataladServerProgressBar,
+      progressText: els.dataladServerProgressText,
+      statusText: els.dataladServerStatusText,
+      resultDiv: els.dataladServerResult,
+      cancelBtn: els.dataladServerCancelBtn,
+    });
+  });
+
+  it('uses a different prefix for a different caller without collision', () => {
+    stubDocument({ rsyncServerProgress: { id: 'rsync-progress' } });
+
+    const els = getProgressEls('rsyncServer');
+    expect(els.progressDiv).toEqual({ id: 'rsync-progress' });
+    expect(els.progressBar).toBeNull();
+  });
+});
+
+describe('setStatusBadge', () => {
+  afterEach(() => {
+    delete globalThis.document;
+  });
+
+  it('sets the badge tone class and text for the given prefix', () => {
+    const badge = { className: '', textContent: '' };
+    stubDocument({ dataladServerStatusBadge: badge });
+
+    setStatusBadge('dataladServer', 'Connected', 'info');
+
+    expect(badge.className).toBe('badge bg-info');
+    expect(badge.textContent).toBe('Connected');
+  });
+
+  it('defaults to the secondary tone', () => {
+    const badge = { className: '', textContent: '' };
+    stubDocument({ rsyncServerStatusBadge: badge });
+
+    setStatusBadge('rsyncServer', 'Checking...');
+
+    expect(badge.className).toBe('badge bg-secondary');
+  });
+
+  it('does nothing when the badge element is missing', () => {
+    stubDocument({});
+    expect(() => setStatusBadge('dataladServer', 'x')).not.toThrow();
+  });
+});

--- a/app/static/js/modules/projects/rsync_server.js
+++ b/app/static/js/modules/projects/rsync_server.js
@@ -7,32 +7,20 @@
  * each sync is additive, optionally followed by a checksum verification.
  */
 
-import { setButtonLoading } from './helpers.js';
+import { getProgressEls, setButtonLoading, setStatusBadge as setStatusBadgeFor } from './helpers.js';
 import { getById, setHtml, hide, show, escapeHtml } from '../../shared/dom.js';
 import { fetchWithApiFallback } from '../../shared/api.js';
 import { resolveCurrentProjectPath } from '../../shared/project-state.js';
 import { openRemoteFolderPicker } from './remote_folder_picker.js';
 
+const PROGRESS_PREFIX = 'rsyncServer';
+
 let rsyncServerModuleInitialized = false;
 let activeJobId = null;
 let activeJobCancelled = false;
 
-function getProgressEls() {
-    return {
-        progressDiv: getById('rsyncServerProgress'),
-        progressBar: getById('rsyncServerProgressBar'),
-        progressText: getById('rsyncServerProgressText'),
-        statusText: getById('rsyncServerStatusText'),
-        resultDiv: getById('rsyncServerResult'),
-        cancelBtn: getById('rsyncServerCancelBtn'),
-    };
-}
-
 function setStatusBadge(text, tone = 'secondary') {
-    const badge = getById('rsyncServerStatusBadge');
-    if (!badge) return;
-    badge.className = `badge bg-${tone}`;
-    badge.textContent = text;
+    setStatusBadgeFor(PROGRESS_PREFIX, text, tone);
 }
 
 /**
@@ -129,7 +117,7 @@ async function onSyncClick() {
     }
     requestData.verify = !!getById('rsyncServerVerify')?.checked;
 
-    const { progressDiv, progressBar, progressText, statusText, resultDiv, cancelBtn } = getProgressEls();
+    const { progressDiv, progressBar, progressText, statusText, resultDiv, cancelBtn } = getProgressEls(PROGRESS_PREFIX);
 
     activeJobCancelled = false;
     activeJobId = null;

--- a/app/static/js/shared/path-picker.test.js
+++ b/app/static/js/shared/path-picker.test.js
@@ -1,0 +1,24 @@
+import { afterEach, describe, expect, it } from 'vitest';
+
+import { prefersServerPicker } from './path-picker.js';
+
+describe('shared prefersServerPicker', () => {
+  afterEach(() => {
+    delete globalThis.window;
+  });
+
+  it('delegates to PrismPathPicker.prefersServerPicker when available', () => {
+    globalThis.window = { PrismPathPicker: { prefersServerPicker: () => true } };
+    expect(prefersServerPicker()).toBe(true);
+  });
+
+  it('falls back to PrismFileSystemMode.prefersServerPicker when PrismPathPicker is unavailable', () => {
+    globalThis.window = { PrismFileSystemMode: { prefersServerPicker: () => true } };
+    expect(prefersServerPicker()).toBe(true);
+  });
+
+  it('returns false when neither picker is available', () => {
+    globalThis.window = {};
+    expect(prefersServerPicker()).toBe(false);
+  });
+});

--- a/vitest.config.js
+++ b/vitest.config.js
@@ -3,6 +3,6 @@ import { defineConfig } from 'vitest/config';
 export default defineConfig({
   test: {
     environment: 'node',
-    include: ['app/static/js/shared/**/*.test.js']
+    include: ['app/static/js/**/*.test.js']
   }
 });


### PR DESCRIPTION
## Summary
- `prefersServerPicker` was independently reimplemented in `index.js`, `file_management.js`, and `modules/converter/server-picker.js`; three of the four copies were missing the `window.PrismFileSystemMode` fallback the canonical `shared/path-picker.js` already had. All three now delegate to it — the ES module via a direct import, the two non-module scripts via the same memoized dynamic-import bridge they already use for `fetchWithApiFallback`.
- `getProgressEls`/`setStatusBadge` were byte-for-byte duplicated between `datalad_server.js` and `rsync_server.js`, differing only by an element-ID prefix. Moved to `modules/projects/helpers.js`, parameterized by prefix.
- `vitest.config.js`'s test glob widened from `shared/**/*.test.js` to `app/static/js/**/*.test.js` so the new tests (outside `shared/`) are discovered.
- Built with TDD: each fix has a test that was watched to fail before the implementation change.

## Test plan
- [x] `npx vitest run` — 4 test files, 15 tests, all passing
- [x] `node --check` on all touched runtime JS files
- [x] Independent code review (general-purpose subagent) on the full diff: no Critical/Important issues, verdict "Ready to merge: Yes"

🤖 Generated with [Claude Code](https://claude.com/claude-code)