### PR TITLE
Rework beginner tutorial Chapters 2-6: hands-on content + real bug fixes

### DIFF
--- a/app/src/cli/commands/survey.py
+++ b/app/src/cli/commands/survey.py
@@ -130,7 +130,7 @@ def cmd_survey_import_excel(args):
 def cmd_survey_convert(args):
     """Convert a wide survey table (currently .xlsx) into a PRISM/BIDS survey dataset."""
     try:
-        from src.converters.survey import convert_survey_xlsx_to_prism_dataset
+        from src.converters.survey import convert_survey_file_to_prism_dataset
     except Exception as e:
         print(f"Error: Could not import survey conversion module: {e}")
         sys.exit(1)
@@ -245,7 +245,7 @@ def cmd_survey_convert(args):
             p = Path(args.project).resolve()
             project_path = p.parent if p.is_file() else p
 
-        result = convert_survey_xlsx_to_prism_dataset(
+        result = convert_survey_file_to_prism_dataset(
             input_path=str(input_path),
             library_dir=str(lib_dir),
             output_root=str(output_root),

--- a/app/src/converters/survey.py
+++ b/app/src/converters/survey.py
@@ -437,7 +437,7 @@ class SurveyResponsesConverter:
         allow_near_item_match: bool = False,
         near_match_tasks: set[str] | None = None,
     ) -> SurveyConvertResult:
-        return _convert_survey_xlsx_to_prism_dataset_impl(
+        return _convert_survey_file_to_prism_dataset_impl(
             input_path=input_path,
             library_dir=library_dir,
             output_root=output_root,
@@ -544,7 +544,7 @@ def _copy_templates_to_project(
     )
 
 
-def _convert_survey_xlsx_to_prism_dataset_impl(
+def _convert_survey_file_to_prism_dataset_impl(
     *,
     input_path: str | Path,
     library_dir: str | Path,
@@ -772,7 +772,7 @@ def _convert_survey_lsa_to_prism_dataset_impl(
     )
 
 
-def convert_survey_xlsx_to_prism_dataset(
+def convert_survey_file_to_prism_dataset(
     *,
     input_path: str | Path,
     library_dir: str | Path,

--- a/app/src/hostile_demo_generator.py
+++ b/app/src/hostile_demo_generator.py
@@ -1522,7 +1522,7 @@ def build_hostile_participants_merge_assets(
                 "on-disk directory, so the second participant written "
                 "silently overwrote the first's file with no error. Fixed: "
                 "convert_biometrics_table_to_prism_dataset and "
-                "convert_survey_xlsx_to_prism_dataset now both call "
+                "convert_survey_file_to_prism_dataset now both call "
                 "src.cross_platform.describe_case_insensitive_id_collisions "
                 "before writing anything and raise a clear ValueError "
                 "instead (see tests/test_hostile_demo_pipeline.py::"

--- a/app/src/web/blueprints/conversion_survey_convert_handlers.py
+++ b/app/src/web/blueprints/conversion_survey_convert_handlers.py
@@ -17,7 +17,7 @@ except ImportError:
 
 def handle_api_survey_convert(
     *,
-    convert_survey_xlsx_to_prism_dataset,
+    convert_survey_file_to_prism_dataset,
     convert_survey_lsa_to_prism_dataset,
     resolve_uploaded_or_source_file,
     resolve_requested_project_root,
@@ -53,7 +53,7 @@ def handle_api_survey_convert(
 ):
     """Run full survey conversion and return ZIP output."""
     if (
-        not convert_survey_xlsx_to_prism_dataset
+        not convert_survey_file_to_prism_dataset
         and not convert_survey_lsa_to_prism_dataset
     ):
         return jsonify({"error": "Survey conversion module not available"}), 500
@@ -206,7 +206,7 @@ def handle_api_survey_convert(
         try:
             preflight_result = survey_workflow_stage_service.run_stage(
                 workflow_runner=run_survey_with_official_fallback,
-                tabular_converter=convert_survey_xlsx_to_prism_dataset,
+                tabular_converter=convert_survey_file_to_prism_dataset,
                 lsa_converter=convert_survey_lsa_to_prism_dataset,
                 options=survey_workflow_stage_options_cls(
                     suffix=suffix,
@@ -328,7 +328,7 @@ def handle_api_survey_convert(
         try:
             convert_result = survey_workflow_stage_service.run_stage(
                 workflow_runner=run_survey_with_official_fallback,
-                tabular_converter=convert_survey_xlsx_to_prism_dataset,
+                tabular_converter=convert_survey_file_to_prism_dataset,
                 lsa_converter=convert_survey_lsa_to_prism_dataset,
                 options=survey_workflow_stage_options_cls(
                     suffix=suffix,

--- a/app/src/web/blueprints/conversion_survey_convert_validate_handlers.py
+++ b/app/src/web/blueprints/conversion_survey_convert_validate_handlers.py
@@ -17,7 +17,7 @@ _survey_convert_job_store = ConversionJobStore(log_level_key="level")
 
 def handle_api_survey_convert_validate(
     *,
-    convert_survey_xlsx_to_prism_dataset,
+    convert_survey_file_to_prism_dataset,
     convert_survey_lsa_to_prism_dataset,
     resolve_uploaded_or_source_file,
     resolve_requested_project_root,
@@ -60,7 +60,7 @@ def handle_api_survey_convert_validate(
 ):
     """Convert survey, save to the active project, and return validation results."""
     if (
-        not convert_survey_xlsx_to_prism_dataset
+        not convert_survey_file_to_prism_dataset
         and not convert_survey_lsa_to_prism_dataset
     ):
         return jsonify({"error": "Survey conversion module not available"}), 500
@@ -218,7 +218,7 @@ def handle_api_survey_convert_validate(
         try:
             preflight_result = survey_workflow_stage_service.run_stage(
                 workflow_runner=run_survey_with_official_fallback,
-                tabular_converter=convert_survey_xlsx_to_prism_dataset,
+                tabular_converter=convert_survey_file_to_prism_dataset,
                 lsa_converter=convert_survey_lsa_to_prism_dataset,
                 options=survey_workflow_stage_options_cls(
                     suffix=suffix,
@@ -383,7 +383,7 @@ def handle_api_survey_convert_validate(
                 add_log(f"Processing LimeSurvey archive: {filename}", "info")
             convert_result = survey_workflow_stage_service.run_stage(
                 workflow_runner=run_survey_with_official_fallback,
-                tabular_converter=convert_survey_xlsx_to_prism_dataset,
+                tabular_converter=convert_survey_file_to_prism_dataset,
                 lsa_converter=convert_survey_lsa_to_prism_dataset,
                 options=survey_workflow_stage_options_cls(
                     suffix=suffix,
@@ -810,7 +810,7 @@ def handle_api_survey_convert_validate(
 
 def handle_api_survey_convert_validate_start(
     *,
-    convert_survey_xlsx_to_prism_dataset,
+    convert_survey_file_to_prism_dataset,
     convert_survey_lsa_to_prism_dataset,
     resolve_uploaded_or_source_file,
     resolve_requested_project_root,
@@ -853,7 +853,7 @@ def handle_api_survey_convert_validate_start(
 ):
     """Start an async survey conversion+validate job and return its job id for polling."""
     if (
-        not convert_survey_xlsx_to_prism_dataset
+        not convert_survey_file_to_prism_dataset
         and not convert_survey_lsa_to_prism_dataset
     ):
         return jsonify({"error": "Survey conversion module not available"}), 500
@@ -1053,7 +1053,7 @@ def handle_api_survey_convert_validate_start(
     }
 
     deps: dict[str, Any] = {
-        "convert_survey_xlsx_to_prism_dataset": convert_survey_xlsx_to_prism_dataset,
+        "convert_survey_file_to_prism_dataset": convert_survey_file_to_prism_dataset,
         "convert_survey_lsa_to_prism_dataset": convert_survey_lsa_to_prism_dataset,
         "survey_workflow_stage_service": survey_workflow_stage_service,
         "survey_workflow_stage_options_cls": survey_workflow_stage_options_cls,
@@ -1143,7 +1143,7 @@ def _run_survey_convert_validate_job(
             result=payload,
         )
 
-    convert_survey_xlsx_to_prism_dataset = deps["convert_survey_xlsx_to_prism_dataset"]
+    convert_survey_file_to_prism_dataset = deps["convert_survey_file_to_prism_dataset"]
     convert_survey_lsa_to_prism_dataset = deps["convert_survey_lsa_to_prism_dataset"]
     survey_workflow_stage_service = deps["survey_workflow_stage_service"]
     survey_workflow_stage_options_cls = deps["survey_workflow_stage_options_cls"]
@@ -1210,7 +1210,7 @@ def _run_survey_convert_validate_job(
         try:
             preflight_result = survey_workflow_stage_service.run_stage(
                 workflow_runner=run_survey_with_official_fallback,
-                tabular_converter=convert_survey_xlsx_to_prism_dataset,
+                tabular_converter=convert_survey_file_to_prism_dataset,
                 lsa_converter=convert_survey_lsa_to_prism_dataset,
                 options=survey_workflow_stage_options_cls(
                     suffix=suffix,
@@ -1368,7 +1368,7 @@ def _run_survey_convert_validate_job(
                 add_log(f"Processing LimeSurvey archive: {filename}", "info")
             convert_result = survey_workflow_stage_service.run_stage(
                 workflow_runner=run_survey_with_official_fallback,
-                tabular_converter=convert_survey_xlsx_to_prism_dataset,
+                tabular_converter=convert_survey_file_to_prism_dataset,
                 lsa_converter=convert_survey_lsa_to_prism_dataset,
                 options=survey_workflow_stage_options_cls(
                     suffix=suffix,

--- a/app/src/web/blueprints/conversion_survey_handlers.py
+++ b/app/src/web/blueprints/conversion_survey_handlers.py
@@ -82,7 +82,7 @@ from .conversion_survey_template_helpers import (
     validate_project_templates_for_tasks,
 )
 
-convert_survey_xlsx_to_prism_dataset: Any = None
+convert_survey_file_to_prism_dataset: Any = None
 convert_survey_lsa_to_prism_dataset: Any = None
 infer_lsa_metadata: Any = None
 from .conversion_survey_version_context_handlers import (
@@ -109,7 +109,7 @@ try:
         UnmatchedGroupsError,
         _NON_ITEM_TOPLEVEL_KEYS,
         convert_survey_lsa_to_prism_dataset,
-        convert_survey_xlsx_to_prism_dataset,
+        convert_survey_file_to_prism_dataset,
         infer_lsa_metadata,
     )
 except ImportError:
@@ -380,7 +380,7 @@ def _infer_tasks_against_official_templates(
         separator_option=separator_option,
         supported_survey_tabular_suffixes=_SUPPORTED_SURVEY_TABULAR_SUFFIXES,
         supported_survey_input_message=_SUPPORTED_SURVEY_INPUT_MESSAGE,
-        convert_survey_xlsx_to_prism_dataset=convert_survey_xlsx_to_prism_dataset,
+        convert_survey_file_to_prism_dataset=convert_survey_file_to_prism_dataset,
         convert_survey_lsa_to_prism_dataset=convert_survey_lsa_to_prism_dataset,
         run_survey_with_official_fallback=_run_survey_with_official_fallback,
     )
@@ -424,7 +424,7 @@ def _detect_survey_version_contexts(
 
         def _run_detection(candidate_library_dir: Path):
             if suffix in _SUPPORTED_SURVEY_TABULAR_SUFFIXES:
-                return convert_survey_xlsx_to_prism_dataset(
+                return convert_survey_file_to_prism_dataset(
                     input_path=input_path,
                     library_dir=str(candidate_library_dir),
                     output_root=output_root,
@@ -646,7 +646,7 @@ def api_survey_prepare_workflow():
     """Run the survey setup phase without starting preview or conversion output."""
     try:
         preview_response = handle_api_survey_convert_preview(
-            convert_survey_xlsx_to_prism_dataset=convert_survey_xlsx_to_prism_dataset,
+            convert_survey_file_to_prism_dataset=convert_survey_file_to_prism_dataset,
             convert_survey_lsa_to_prism_dataset=convert_survey_lsa_to_prism_dataset,
             resolve_effective_library_path=_resolve_effective_library_path,
             run_survey_with_official_fallback=_run_survey_with_official_fallback,
@@ -825,7 +825,7 @@ def api_survey_detect_version_context():
 
 def api_survey_convert_preview():
     return handle_api_survey_convert_preview(
-        convert_survey_xlsx_to_prism_dataset=convert_survey_xlsx_to_prism_dataset,
+        convert_survey_file_to_prism_dataset=convert_survey_file_to_prism_dataset,
         convert_survey_lsa_to_prism_dataset=convert_survey_lsa_to_prism_dataset,
         resolve_effective_library_path=_resolve_effective_library_path,
         run_survey_with_official_fallback=_run_survey_with_official_fallback,
@@ -841,7 +841,7 @@ def api_survey_convert_preview():
 
 def api_survey_convert():
     return handle_api_survey_convert(
-        convert_survey_xlsx_to_prism_dataset=convert_survey_xlsx_to_prism_dataset,
+        convert_survey_file_to_prism_dataset=convert_survey_file_to_prism_dataset,
         convert_survey_lsa_to_prism_dataset=convert_survey_lsa_to_prism_dataset,
         resolve_uploaded_or_source_file=_resolve_uploaded_or_source_file,
         resolve_requested_project_root=_resolve_requested_project_root,
@@ -879,7 +879,7 @@ def api_survey_convert():
 
 def api_survey_convert_validate():
     return handle_api_survey_convert_validate(
-        convert_survey_xlsx_to_prism_dataset=convert_survey_xlsx_to_prism_dataset,
+        convert_survey_file_to_prism_dataset=convert_survey_file_to_prism_dataset,
         convert_survey_lsa_to_prism_dataset=convert_survey_lsa_to_prism_dataset,
         resolve_uploaded_or_source_file=_resolve_uploaded_or_source_file,
         resolve_requested_project_root=_resolve_requested_project_root,
@@ -924,7 +924,7 @@ def api_survey_convert_validate():
 
 def api_survey_convert_validate_start():
     return handle_api_survey_convert_validate_start(
-        convert_survey_xlsx_to_prism_dataset=convert_survey_xlsx_to_prism_dataset,
+        convert_survey_file_to_prism_dataset=convert_survey_file_to_prism_dataset,
         convert_survey_lsa_to_prism_dataset=convert_survey_lsa_to_prism_dataset,
         resolve_uploaded_or_source_file=_resolve_uploaded_or_source_file,
         resolve_requested_project_root=_resolve_requested_project_root,

--- a/app/src/web/blueprints/conversion_survey_official_template_helpers.py
+++ b/app/src/web/blueprints/conversion_survey_official_template_helpers.py
@@ -188,7 +188,7 @@ def infer_tasks_against_official_templates(
     separator_option: str,
     supported_survey_tabular_suffixes: set[str] | tuple[str, ...],
     supported_survey_input_message: str,
-    convert_survey_xlsx_to_prism_dataset,
+    convert_survey_file_to_prism_dataset,
     convert_survey_lsa_to_prism_dataset,
     run_survey_with_official_fallback,
 ) -> dict[str, Any]:
@@ -230,7 +230,7 @@ def infer_tasks_against_official_templates(
         preflight_output_root = tmp_dir_path / "preflight_rawdata"
         if suffix in supported_survey_tabular_suffixes:
             result = run_survey_with_official_fallback(
-                convert_survey_xlsx_to_prism_dataset,
+                convert_survey_file_to_prism_dataset,
                 input_path=input_path,
                 library_dir=str(survey_official_dir),
                 output_root=preflight_output_root,

--- a/app/src/web/blueprints/conversion_survey_preview_handlers.py
+++ b/app/src/web/blueprints/conversion_survey_preview_handlers.py
@@ -342,7 +342,7 @@ def handle_api_survey_languages(participant_json_candidates):
 
 def handle_api_survey_convert_preview(
     *,
-    convert_survey_xlsx_to_prism_dataset,
+    convert_survey_file_to_prism_dataset,
     convert_survey_lsa_to_prism_dataset,
     resolve_effective_library_path,
     run_survey_with_official_fallback,
@@ -357,7 +357,7 @@ def handle_api_survey_convert_preview(
 ):
     """Run a dry-run conversion to preview what will be created without writing files."""
     if (
-        not convert_survey_xlsx_to_prism_dataset
+        not convert_survey_file_to_prism_dataset
         and not convert_survey_lsa_to_prism_dataset
     ):
         return jsonify({"error": "Survey conversion module not available"}), 500
@@ -541,7 +541,7 @@ def handle_api_survey_convert_preview(
 
         if suffix in _SUPPORTED_SURVEY_TABULAR_SUFFIXES:
             result = run_survey_with_official_fallback(
-                convert_survey_xlsx_to_prism_dataset,
+                convert_survey_file_to_prism_dataset,
                 input_path=input_path,
                 library_dir=str(effective_survey_dir),
                 output_root=output_root,
@@ -660,7 +660,7 @@ def handle_api_survey_convert_preview(
 
                 if suffix in _SUPPORTED_SURVEY_TABULAR_SUFFIXES:
                     return run_survey_with_official_fallback(
-                        convert_survey_xlsx_to_prism_dataset,
+                        convert_survey_file_to_prism_dataset,
                         input_path=input_path,
                         library_dir=str(effective_survey_dir),
                         output_root=task_validate_root,
@@ -733,7 +733,7 @@ def handle_api_survey_convert_preview(
                 try:
                     if suffix in _SUPPORTED_SURVEY_TABULAR_SUFFIXES:
                         run_survey_with_official_fallback(
-                            convert_survey_xlsx_to_prism_dataset,
+                            convert_survey_file_to_prism_dataset,
                             input_path=input_path,
                             library_dir=str(effective_survey_dir),
                             output_root=validate_root,

--- a/app/static/js/beginner-help-registry.js
+++ b/app/static/js/beginner-help-registry.js
@@ -9,7 +9,7 @@
         globalRecipesPath: 'Set a shared recipe root that contains a recipe/ folder with recipe JSON files.',
         backendMonitoringToggle: 'Turn on terminal traces for backend requests and command execution.',
         dedicatedTerminalToggle: 'Open a separate terminal for startup logs. This applies after the next app launch.',
-        convertExcelFile: 'Select the survey source file to convert (Excel, CSV/TSV, SPSS SAV, R data, or LimeSurvey archive).',
+        convertSurveyFile: 'Select the survey source file to convert (Excel, CSV/TSV, SPSS SAV, R data, or LimeSurvey archive).',
         datasetFolder: 'Select the dataset root folder to validate when using the alternative target option.',
         library_path: 'Optional override for template library root. Leave empty to use automatic default detection.',
         convertSeparator: 'Set this only if automatic delimiter detection picked the wrong separator.',

--- a/app/static/js/converter-bootstrap.js
+++ b/app/static/js/converter-bootstrap.js
@@ -48,7 +48,7 @@ document.addEventListener('DOMContentLoaded', function() {
         sessionPickerController.populateSessionPickers(projectPath);
     }
 
-    const convertExcelFile = document.getElementById('convertExcelFile');
+    const convertSurveyFile = document.getElementById('convertSurveyFile');
     const convertBtn = document.getElementById('convertBtn');
     const previewBtn = document.getElementById('previewBtn');
     const participantsDataFile = document.getElementById('participantsDataFile');
@@ -71,9 +71,9 @@ document.addEventListener('DOMContentLoaded', function() {
         appendLog(`[${modality}] ${message}`, 'warning');
     });
 
-    if (convertExcelFile && convertBtn) {
+    if (convertSurveyFile && convertBtn) {
         initSurveyConvert({
-            convertExcelFile,
+            convertSurveyFile,
             convertSeparator: document.getElementById('convertSeparator'),
             surveySeparatorGroup: document.getElementById('surveySeparatorGroup'),
             clearConvertExcelFileBtn: document.getElementById('clearConvertExcelFileBtn'),

--- a/app/static/js/modules/converter/survey-convert.js
+++ b/app/static/js/modules/converter/survey-convert.js
@@ -61,7 +61,7 @@ import { createSurveyWorkflowPreviewController } from './survey-workflow-preview
 export function initSurveyConvert(elements) {
     const {
         // Survey Convert DOM elements
-        convertExcelFile,
+        convertSurveyFile,
         convertSeparator,
         surveySeparatorGroup,
         clearConvertExcelFileBtn,
@@ -191,7 +191,7 @@ export function initSurveyConvert(elements) {
     const surveyWorkflowResponseController = createSurveyWorkflowResponseController();
     const { parseJsonResponse } = surveyWorkflowResponseController;
     const surveySelectedInputController = createSurveySelectedInputController({
-        convertExcelFile,
+        convertSurveyFile,
         getConvertServerFilePath: () => convertServerFilePath,
     });
     const {
@@ -237,7 +237,7 @@ export function initSurveyConvert(elements) {
     const surveySourcedataQuickSelectController = createSurveySourcedataQuickSelectController({
         sourcedataQuickSelect,
         sourcedataFileSelect,
-        convertExcelFile,
+        convertSurveyFile,
         convertError,
         resolveCurrentProjectPath,
         onProjectChanged: () => {
@@ -671,9 +671,9 @@ export function initSurveyConvert(elements) {
             browseServerSurveyFileBtn.classList.toggle('d-none', !connectedToServer);
         }
 
-        if (convertExcelFile) {
-            convertExcelFile.disabled = connectedToServer;
-            convertExcelFile.title = connectedToServer ? 'Connected-to-server mode: use Browse Server File.' : '';
+        if (convertSurveyFile) {
+            convertSurveyFile.disabled = connectedToServer;
+            convertSurveyFile.title = connectedToServer ? 'Connected-to-server mode: use Browse Server File.' : '';
         }
     }
 
@@ -1842,7 +1842,7 @@ export function initSurveyConvert(elements) {
         });
     }
 
-    convertExcelFile.addEventListener('change', async function() {
+    convertSurveyFile.addEventListener('change', async function() {
         convertServerFilePath = '';
         resetSurveyRefreshFingerprint();
         const file = this.files?.[0];
@@ -1876,8 +1876,8 @@ export function initSurveyConvert(elements) {
     clearConvertExcelFileBtn?.addEventListener('click', function() {
         convertServerFilePath = '';
         resetSurveyRefreshFingerprint();
-        convertExcelFile.value = '';
-        convertExcelFile.dispatchEvent(new Event('change', { bubbles: true }));
+        convertSurveyFile.value = '';
+        convertSurveyFile.dispatchEvent(new Event('change', { bubbles: true }));
         surveyImportFormStateController.resetSurveyImportFormState();
     });
 
@@ -1949,8 +1949,8 @@ export function initSurveyConvert(elements) {
 
             convertServerFilePath = pickedPath;
             resetSurveyRefreshFingerprint();
-            if (convertExcelFile) {
-                convertExcelFile.value = '';
+            if (convertSurveyFile) {
+                convertSurveyFile.value = '';
             }
 
             templateWorkflowGate = null;
@@ -2339,7 +2339,7 @@ export function initSurveyConvert(elements) {
         convertSessionSelect,
         convertSessionCustom,
         convertAdvancedToggle,
-        convertExcelFile,
+        convertSurveyFile,
         templateResultsContainer,
         convertInfo,
         convertError,

--- a/app/static/js/modules/converter/survey-import-form-state.js
+++ b/app/static/js/modules/converter/survey-import-form-state.js
@@ -5,7 +5,7 @@ export function createSurveyImportFormStateController({
     convertSessionSelect,
     convertSessionCustom,
     convertAdvancedToggle,
-    convertExcelFile,
+    convertSurveyFile,
     templateResultsContainer,
     convertInfo,
     convertError,
@@ -75,8 +75,8 @@ export function createSurveyImportFormStateController({
 
         if (clearSelectedInput) {
             setConvertServerFilePath('');
-            if (convertExcelFile) {
-                convertExcelFile.value = '';
+            if (convertSurveyFile) {
+                convertSurveyFile.value = '';
             }
         }
         surveySourcedataQuickSelectController.clearSelectedFile();

--- a/app/static/js/modules/converter/survey-selected-input-controller.js
+++ b/app/static/js/modules/converter/survey-selected-input-controller.js
@@ -1,12 +1,12 @@
 export function createSurveySelectedInputController({
-    convertExcelFile = null,
+    convertSurveyFile = null,
     getConvertServerFilePath = () => '',
 } = {}) {
     const getServerFilePath = () => String(getConvertServerFilePath() || '');
 
     function getSelectedSurveyFile() {
-        return (convertExcelFile && convertExcelFile.files && convertExcelFile.files[0])
-            ? convertExcelFile.files[0]
+        return (convertSurveyFile && convertSurveyFile.files && convertSurveyFile.files[0])
+            ? convertSurveyFile.files[0]
             : null;
     }
 

--- a/app/static/js/modules/converter/survey-sourcedata-quick-select.js
+++ b/app/static/js/modules/converter/survey-sourcedata-quick-select.js
@@ -3,7 +3,7 @@ import { fetchWithApiFallback } from '../../shared/api.js';
 export function createSurveySourcedataQuickSelectController({
     sourcedataQuickSelect,
     sourcedataFileSelect,
-    convertExcelFile,
+    convertSurveyFile,
     convertError,
     resolveCurrentProjectPath,
     onProjectChanged,
@@ -16,11 +16,11 @@ export function createSurveySourcedataQuickSelectController({
         if (sourcedataQuickSelectEl && sourcedataFileSelectEl) {
             return;
         }
-        if (!convertExcelFile) {
+        if (!convertSurveyFile) {
             return;
         }
 
-        const pickerContainer = convertExcelFile.closest('.studio-file-picker');
+        const pickerContainer = convertSurveyFile.closest('.studio-file-picker');
         if (pickerContainer) {
             sourcedataQuickSelectEl = sourcedataQuickSelectEl || pickerContainer.querySelector('#sourcedataQuickSelect');
             sourcedataFileSelectEl = sourcedataFileSelectEl || pickerContainer.querySelector('#sourcedataFileSelect');
@@ -30,7 +30,7 @@ export function createSurveySourcedataQuickSelectController({
             return;
         }
 
-        const inputGroup = convertExcelFile.closest('.input-group');
+        const inputGroup = convertSurveyFile.closest('.input-group');
         if (!inputGroup || !inputGroup.parentElement) {
             return;
         }
@@ -187,8 +187,8 @@ export function createSurveySourcedataQuickSelectController({
                 const file = new File([blob], filename, { type: blob.type });
                 const dataTransfer = new DataTransfer();
                 dataTransfer.items.add(file);
-                convertExcelFile.files = dataTransfer.files;
-                convertExcelFile.dispatchEvent(new Event('change', { bubbles: true }));
+                convertSurveyFile.files = dataTransfer.files;
+                convertSurveyFile.dispatchEvent(new Event('change', { bubbles: true }));
             } catch (error) {
                 console.error('Failed to load sourcedata file:', error);
                 convertError.textContent = `Failed to load ${filename} from sourcedata.`;

--- a/app/templates/converter_survey.html
+++ b/app/templates/converter_survey.html
@@ -45,7 +45,7 @@
                             <!-- Row 1: File upload -->
                             <div class="row g-3 mb-3">
                                 <div class="col-12 studio-file-picker">
-                                    <label for="convertExcelFile" class="form-label">Survey File (.xlsx, .csv, .tsv, .sav, .rds, .rdata, .lsa)</label>
+                                    <label for="convertSurveyFile" class="form-label">Survey File (.xlsx, .csv, .tsv, .sav, .rds, .rdata, .lsa)</label>
                                     <div id="sourcedataQuickSelect" class="d-none mb-2">
                                         <div class="input-group input-group-sm">
                                             <span class="input-group-text bg-light"><i class="fas fa-folder-open text-muted"></i></span>
@@ -55,7 +55,7 @@
                                         </div>
                                     </div>
                                     <div class="input-group studio-picker-group">
-                                        <input class="form-control" type="file" id="convertExcelFile" accept=".xlsx,.lsa,.csv,.tsv,.sav,.rds,.rdata,.rda" data-help-key="convertExcelFile">
+                                        <input class="form-control" type="file" id="convertSurveyFile" accept=".xlsx,.lsa,.csv,.tsv,.sav,.rds,.rdata,.rda" data-help-key="convertSurveyFile">
                                         <button class="btn btn-outline-secondary d-none" type="button" id="browseServerSurveyFileBtn" aria-label="Browse server survey file" title="Browse server survey file">
                                             <i class="fas fa-server me-1"></i>Server
                                         </button>

--- a/docs/TUTORIAL_BEGINNER.md
+++ b/docs/TUTORIAL_BEGINNER.md
@@ -92,11 +92,11 @@ guess.
     <span class="prism-chapter-icon">2</span>
     <span class="prism-chapter-title">Import Sociodemographic Data</span>
     <span class="prism-chapter-outcome"><code>participants.tsv</code> / <code>participants.json</code></span>
-    <span class="prism-chapter-time">~15 min</span>
+    <span class="prism-chapter-time">~20 min</span>
   </a>
   <a class="prism-chapter-card" href="TUTORIAL_BEGINNER_3_SURVEY_IMPORT.html">
     <span class="prism-chapter-icon">3</span>
-    <span class="prism-chapter-title">Import a Survey via Excel</span>
+    <span class="prism-chapter-title">Import Survey Response Data</span>
     <span class="prism-chapter-outcome">Survey response files written into subject folders</span>
     <span class="prism-chapter-time">~25 min</span>
   </a>

--- a/docs/TUTORIAL_BEGINNER.md
+++ b/docs/TUTORIAL_BEGINNER.md
@@ -11,7 +11,9 @@ This sits alongside another on-ramp:
 instructor-led session. Use this tutorial if you want the most explanation and
 plan to work through it alone.
 
-**Time:** ~100 minutes for all six chapters. **Outcome:** one new project
+**Time:** ~130 minutes for all six chapters (most of the added time is
+hands-on practice, plus Chapter 6's dataset download). **Outcome:** one new
+project
 (`wellbeing_study`) with sociodemographic data, imported survey responses, a
 working scoring recipe, validated — plus experience enriching an existing BIDS
 dataset with the same tools.
@@ -104,7 +106,7 @@ guess.
     <span class="prism-chapter-icon">4</span>
     <span class="prism-chapter-title">Prepare a Recipe</span>
     <span class="prism-chapter-outcome">A saved, working scoring recipe and its output</span>
-    <span class="prism-chapter-time">~15 min</span>
+    <span class="prism-chapter-time">~20 min</span>
   </a>
   <a class="prism-chapter-card" href="TUTORIAL_BEGINNER_5_VALIDATOR.html">
     <span class="prism-chapter-icon">5</span>
@@ -116,7 +118,7 @@ guess.
     <span class="prism-chapter-icon">6</span>
     <span class="prism-chapter-title">Enrich an Existing BIDS Dataset</span>
     <span class="prism-chapter-outcome">Same workflow applied to a published OpenNeuro dataset</span>
-    <span class="prism-chapter-time">~15 min</span>
+    <span class="prism-chapter-time">~30 min</span>
   </a>
 </div>
 

--- a/docs/TUTORIAL_BEGINNER.md
+++ b/docs/TUTORIAL_BEGINNER.md
@@ -110,7 +110,7 @@ guess.
     <span class="prism-chapter-icon">5</span>
     <span class="prism-chapter-title">Use the Validator</span>
     <span class="prism-chapter-outcome">Validation findings understood and resolved</span>
-    <span class="prism-chapter-time">~15 min</span>
+    <span class="prism-chapter-time">~20 min</span>
   </a>
   <a class="prism-chapter-card" href="TUTORIAL_BEGINNER_6_EXISTING_BIDS.html">
     <span class="prism-chapter-icon">6</span>

--- a/docs/TUTORIAL_BEGINNER_2_PARTICIPANTS.md
+++ b/docs/TUTORIAL_BEGINNER_2_PARTICIPANTS.md
@@ -18,8 +18,9 @@ In this chapter, `participants.tsv` is a table with one row for each person.
 `participants.json` explains columns such as `participant_id`, `age`, and
 `sex`, including any codes used in the table.
 
-**Time:** ~15 minutes. **Outcome:** a matching `participants.tsv` and
-`participants.json` pair written into `wellbeing_study`.
+**Time:** ~20 minutes. **Outcome:** a matching `participants.tsv` and
+`participants.json` pair written into `wellbeing_study`, plus hands-on
+experience with PRISM's Merge workflow for updating them later.
 
 <div class="prism-persona-note" data-persona-note>
 <p class="prism-persona-note-empty" data-persona-empty>Picked a persona on the <a href="TUTORIAL_BEGINNER.html#pick-a-reason-to-be-here">intro page</a>? This note speaks to it.</p>
@@ -99,6 +100,16 @@ tab is the default/first tab.
 - **Participant ID Column** defaults to "Auto-detect", which recognizes
   `participant_id` directly here — no need to override it for this file.
 
+```{tip}
+**What if my ID column isn't called `participant_id`?** Auto-detect also
+recognizes `participantid`, `prism_participant_id`, and `prismparticipantid`
+directly, and falls back to `subject_id`, `sub_id`, `subject`, `sub`, `id`,
+or any column whose name contains both "participant" and "id". If your file
+uses something else entirely (e.g. `PID`), just pick it manually from the
+**Participant ID Column** dropdown — auto-detect is a convenience, not a
+requirement.
+```
+
 ## 5. Review Participant Fields
 
 Click **Review Participant Fields** to preview detected columns and sample
@@ -111,6 +122,17 @@ one-time-per-participant demographics with repeated-measure survey data,
 which don't belong in the same file. Use **Add More Columns (Optional)**
 only if you want to bring in additional demographic-style columns beyond
 what's auto-detected — not for the survey items.
+
+```{note}
+**Where did the `session` column go?** You won't see it in the preview,
+and it won't be in the output either. `participants.tsv` is a BIDS
+requirement of one row per participant, not one row per visit, so
+session-like columns (`session`, `ses`, `visit`, `run`, ...) are dropped
+before PRISM collapses the source rows down to one per participant. Session
+information itself isn't lost — it belongs on the survey/biometrics files
+you'll create in later chapters, each of which carries its own `ses-`
+label.
+```
 
 ## 6. Create Participant Files
 
@@ -154,23 +176,78 @@ naming scheme you will never have to reverse-engineer later.
 </div>
 </div>
 
+## 7. Optional: update participants with Merge
+
+Real studies rarely stop at one import. A more common situation: you already
+have `participants.tsv`, and a source file arrives with **one new
+participant** and a **corrected value** for someone already in the project.
+This step shows what PRISM does with that — and, just as importantly, what
+it deliberately refuses to do.
+
+1. Make your own working copy of the source file rather than editing the
+   shared example directly: copy
+   `examples/workshop/exercise_1_raw_data/raw_data/wellbeing.tsv` somewhere
+   convenient (Desktop, or your project folder) and rename it, e.g.
+   `wellbeing_update.tsv`.
+2. Open the copy in a spreadsheet or text editor and make two changes:
+   - Add one new row for a participant not yet in your project, e.g.
+     `DEMO010`, with plausible values for every column.
+   - Change `DEMO003`'s `age` value to something else (e.g. `22` → `23`) —
+     pretend you just noticed a typo in the original data.
+3. Back in **Converter → Sociodemographics**, since `participants.tsv`
+   already exists in this project, you'll now be asked to choose a
+   workflow first: **Replace** (the imported file becomes the new source of
+   truth), **Modify** (edit the current files in place), or **Merge** (safe
+   merge from an imported table). Choose **Merge**.
+4. Upload `wellbeing_update.tsv` and click **Preview Merge**. The Merge
+   Summary shows counts for matched participants, new participants, filled
+   values, and conflicts. You should see `1 new participant` (DEMO010) and
+   `1 conflict` (DEMO003's `age`).
+
+```{warning}
+**Merge won't overwrite an existing value, even to fix it.** It only fills
+in *missing* values, adds new participants, and adds new columns — any
+non-empty value that differs from what's already in `participants.tsv`
+is reported as a conflict, and **Apply Merge stays blocked** until it's
+resolved. This is deliberate: Merge assumes your project's existing data is
+correct unless you tell PRISM otherwise. Use **Download Conflict Report**
+to see exactly what disagreed. To actually correct a value (as opposed to
+adding new information), use **Modify** or a full **Replace** instead —
+Merge is the safe option for enrichment, not the tool for corrections.
+```
+
+5. For this exercise, you don't need to resolve the conflict — you've seen
+   what Merge does and doesn't do. If you want to see a clean **Apply
+   Merge** succeed, remove the `DEMO003` edit from your copy (keep only the
+   new `DEMO010` row) and preview again; with zero conflicts, **Apply
+   Merge** becomes available and adds the new participant without touching
+   anyone else's data.
+
 ## Common mistakes
 
-- **Including `WB01`-`WB05` as participant fields** — they're repeated
-  survey responses, not one-time demographics; keep them out of
-  `participants.tsv` and import them via the Survey converter in chapter 3
-  instead.
-- **Re-running this step later without noticing the overwrite warning** — if
-  `participants.tsv`/`.json` already exist, you'll be asked to confirm before
-  they're overwritten; read that warning rather than clicking through it.
-- **Expecting raw demographic codes to be relabeled automatically** — there
-  is no value-recoding step here. Raw values (e.g. a numeric sex code) are
-  preserved as-is in `participants.tsv`; labeling what a code means happens
-  separately via the "Participant Annotation" panel into `participants.json`,
-  and turning coded values into readable labels project-wide is covered by
-  the optional participant-mapping workflow (see
-  `examples/workshop/exercise_5_participant_mapping/` for a worked example) —
-  not required for this tutorial.
+```{warning}
+**Including `WB01`-`WB05` as participant fields.** They're repeated survey
+responses, not one-time demographics; keep them out of `participants.tsv`
+and import them via the Survey converter in chapter 3 instead.
+```
+
+```{warning}
+**Re-running this step later without noticing the workflow choice.** Once
+`participants.tsv` exists, PRISM makes you pick Replace, Modify, or Merge
+before anything else — read that choice rather than clicking through it.
+Replace and a resolved Merge both write over the current files.
+```
+
+```{tip}
+**Raw demographic codes aren't relabeled automatically, and that's normal.**
+There is no value-recoding step here. Raw values (e.g. a numeric sex code)
+are preserved as-is in `participants.tsv`; labeling what a code means
+happens separately via the "Participant Annotation" panel into
+`participants.json`, and turning coded values into readable labels
+project-wide is covered by the optional participant-mapping workflow (see
+`examples/workshop/exercise_5_participant_mapping/` for a worked example) —
+not required for this tutorial.
+```
 
 ## What's next
 

--- a/docs/TUTORIAL_BEGINNER_2_PARTICIPANTS.md
+++ b/docs/TUTORIAL_BEGINNER_2_PARTICIPANTS.md
@@ -188,10 +188,13 @@ it deliberately refuses to do.
    shared example directly: copy
    `examples/workshop/exercise_1_raw_data/raw_data/wellbeing.tsv` somewhere
    convenient (Desktop, or your project folder) and rename it, e.g.
-   `wellbeing_update.tsv`.
+   `wellbeing_update.tsv`. (This file has all 20 of the same participants
+   you already imported in step 6 via `wellbeing.xlsx` — same data, just a
+   different format.)
 2. Open the copy in a spreadsheet or text editor and make two changes:
-   - Add one new row for a participant not yet in your project, e.g.
-     `DEMO010`, with plausible values for every column.
+   - Add one new row for a participant not yet in your project — everyone
+     up to `DEMO020` is already there, so use `DEMO021`, with plausible
+     values for every column.
    - Change `DEMO003`'s `age` value to something else (e.g. `22` → `23`) —
      pretend you just noticed a typo in the original data.
 3. Back in **Converter → Sociodemographics**, since `participants.tsv`
@@ -201,7 +204,7 @@ it deliberately refuses to do.
    merge from an imported table). Choose **Merge**.
 4. Upload `wellbeing_update.tsv` and click **Preview Merge**. The Merge
    Summary shows counts for matched participants, new participants, filled
-   values, and conflicts. You should see `1 new participant` (DEMO010) and
+   values, and conflicts. You should see `1 new participant` (DEMO021) and
    `1 conflict` (DEMO003's `age`).
 
 ```{warning}
@@ -219,7 +222,7 @@ Merge is the safe option for enrichment, not the tool for corrections.
 5. For this exercise, you don't need to resolve the conflict — you've seen
    what Merge does and doesn't do. If you want to see a clean **Apply
    Merge** succeed, remove the `DEMO003` edit from your copy (keep only the
-   new `DEMO010` row) and preview again; with zero conflicts, **Apply
+   new `DEMO021` row) and preview again; with zero conflicts, **Apply
    Merge** becomes available and adds the new participant without touching
    anyone else's data.
 
@@ -251,6 +254,6 @@ not required for this tutorial.
 
 ## What's next
 
-- [Chapter 3 — Import a survey via Excel](TUTORIAL_BEGINNER_3_SURVEY_IMPORT.md)
+- [Chapter 3 — Import survey response data](TUTORIAL_BEGINNER_3_SURVEY_IMPORT.md)
 - [Converter — Participants](studio/converter_participants.md) — full
   reference for this screen

--- a/docs/TUTORIAL_BEGINNER_3_SURVEY_IMPORT.md
+++ b/docs/TUTORIAL_BEGINNER_3_SURVEY_IMPORT.md
@@ -1,4 +1,4 @@
-# Chapter 3: Import a Survey via Excel
+# Chapter 3: Import Survey Response Data
 
 Chapter 3 of [Getting Started — Your First PRISM Project](TUTORIAL_BEGINNER.md).
 This is about turning the five wellbeing-survey columns (`WB01`-`WB05`) in
@@ -6,6 +6,13 @@ This is about turning the five wellbeing-survey columns (`WB01`-`WB05`) in
 two parts: getting a survey **template** in place (the JSON that describes
 what the instrument and its items are), then actually **importing the
 response data** against that template.
+
+```{tip}
+This tutorial's running example happens to be an Excel workbook, but Survey
+Import isn't an Excel-only feature. The Converter accepts `.xlsx`, `.csv`,
+`.tsv`, `.sav` (SPSS), `.rds`/`.rdata`/`.rda` (R), and `.lsa` (LimeSurvey
+Archive) — see the format note in Part B, step 3.
+```
 
 **Time:** ~25 minutes. **Outcome:** survey response files for every
 participant, written into subject-level folders under `wellbeing_study`.
@@ -86,6 +93,15 @@ back to this page for Part B once you have a saved template either way.
 Select `examples/workshop/exercise_1_raw_data/raw_data/wellbeing.xlsx` as
 the **Survey File**.
 
+```{tip}
+The same folder also has `wellbeing.tsv` — the identical data as a plain
+tab-separated file. If you'd rather try the CSV/TSV path than Excel, select
+that file instead: a **Separator** dropdown appears for delimited files
+(auto-detect gets tab-separated files right, so you shouldn't need to
+change it). Everything from here on works the same either way — the two
+files convert to the same output.
+```
+
 ### 3. Confirm the required mapping
 
 - **Participant ID Column** — select `participant_id` explicitly rather than
@@ -102,9 +118,13 @@ instrument, so there's nothing to narrow down.
 ### 4. Preview (dry-run)
 
 Click **Preview**. This runs the conversion against a temporary location
-without touching your project — check that it reports 5 participants found,
-task `wellbeing` included, and no missing items. Fix the mapping in step 3
-and re-preview if anything looks off before moving on.
+without touching your project — check that it reports 20 participants
+found, task `wellbeing` included, and no missing items. (You'll also see a
+note about one unmapped column, `sleep` — that's expected: it isn't part of
+the `wellbeing` template, so Survey Import ignores it. Unmapped columns are
+only a problem if a column you *expected* to be picked up is missing.) Fix
+the mapping in step 3 and re-preview if anything looks off before moving
+on.
 
 ### 5. Convert
 
@@ -149,21 +169,60 @@ it. You could open this in five years and still know what a `3` meant.
 </div>
 </div>
 
+## Beyond spreadsheets: SPSS, R, and LimeSurvey
+
+Everything above works the same for the other five formats Survey Import
+accepts:
+
+- **SPSS** (`.sav`) and **R** (`.rds`, `.rdata`, `.rda`) — select the file the
+  same way; PRISM reads the labelled/typed columns directly. See
+  [Converter — Survey Import](studio/converter_survey.md) for format-specific
+  notes.
+- **LimeSurvey** (`.lsa`, a LimeSurvey Archive export) — this is different
+  enough from a plain spreadsheet (it carries its own question/answer
+  structure) that it gets its own walkthrough: see
+  [LimeSurvey Integration](LIMESURVEY_INTEGRATION.md).
+
 ## Common mistakes
 
-- **Importing before a `wellbeing` template exists in the project** — Part A
-  has to come first; if you skip straight to Part B, the converter won't
-  know how to type or label `WB01`-`WB05`.
-- **Item columns that don't match the template's `ItemID`s** — the template
-  expects exactly `WB01`-`WB05`; renamed or extra columns in a modified
-  source file will show up as "missing items" in Preview.
-- **Forgetting only one session converts per run** — if your own future data
-  has more than one session value in the same file, you'll need one Convert
-  pass per session, not one pass for everything.
-- **Running Convert without a participant registry yet** — if you skipped
-  [Chapter 2](TUTORIAL_BEGINNER_2_PARTICIPANTS.md) and `participants.tsv`
-  doesn't exist yet, you'll see a registry warning for IDs not already
-  known to the project; do Chapter 2 first.
+```{warning}
+**Importing before a `wellbeing` template exists in the project.** Part A
+has to come first; if you skip straight to Part B, the converter won't know
+how to type or label `WB01`-`WB05`.
+```
+
+```{warning}
+**Item columns that don't match the template's `ItemID`s.** The template
+expects exactly `WB01`-`WB05`; renamed or extra columns in a modified source
+file will show up as missing/unmapped items in Preview.
+```
+
+```{note}
+**A failed Preview isn't a broken file — it's the whole point of Preview.**
+Adapted from the *PRISM without Panic* guide (ANC Salzburg). The most common
+reasons a dry-run comes back with problems: the column names in your file
+don't match the template's item keys; the participant ID column wasn't
+detected correctly; session information was selected incorrectly; or the
+file's format/delimiter wasn't read as expected. If the message specifically
+mentions unmatched columns: open the **Template Editor**, find your survey
+under Global or Project Templates, and use its read-only item view to
+compare item names against your file's column headers — then fix the
+naming in *your* spreadsheet, not the template, unless the template is
+genuinely wrong. Re-run Preview once the names line up.
+```
+
+```{warning}
+**Forgetting only one session converts per run.** If your own future data
+has more than one session value in the same file, you'll need one Convert
+pass per session, not one pass for everything.
+```
+
+```{warning}
+**Running Convert without a participant registry yet.** If you skipped
+[Chapter 2](TUTORIAL_BEGINNER_2_PARTICIPANTS.md) and `participants.tsv`
+doesn't exist yet, you'll see a registry warning for IDs not already known
+to the project; do Chapter 2 first.
+```
 
 ## What's next
 

--- a/docs/TUTORIAL_BEGINNER_3_SURVEY_IMPORT.md
+++ b/docs/TUTORIAL_BEGINNER_3_SURVEY_IMPORT.md
@@ -132,13 +132,20 @@ Click **Convert**. This writes the real output, e.g.:
 
 ```text
 sub-DEMO001/ses-baseline/survey/sub-DEMO001_ses-baseline_task-wellbeing_survey.tsv
-sub-DEMO001/ses-baseline/survey/sub-DEMO001_ses-baseline_task-wellbeing_survey.json
+sub-DEMO002/ses-baseline/survey/sub-DEMO002_ses-baseline_task-wellbeing_survey.tsv
+...
+task-wellbeing_survey.json
 ```
 
-one pair of files per participant. If you used the fast-path template
-(already project-local), no extra copy step happens on Convert; if the
-template had come from the official/global library instead, Convert would
-copy it into `code/library/survey/` automatically at this point.
+one `.tsv` per participant, but **one shared `.json` sidecar** at the
+dataset root rather than one per participant — this is BIDS's inheritance
+principle: a root-level sidecar applies to every matching file below it
+unless a more specific one overrides it, and PRISM writes it this way
+deliberately to avoid 20 identical copies of the same item descriptions.
+If you used the fast-path template (already project-local), no extra copy
+step happens on Convert; if the template had come from the official/global
+library instead, Convert would copy it into `code/library/survey/`
+automatically at this point.
 
 <div class="prism-persona-note" data-persona-note>
 <p class="prism-persona-note-empty" data-persona-empty>Picked a persona on the <a href="TUTORIAL_BEGINNER.html#pick-a-reason-to-be-here">intro page</a>? This note speaks to it.</p>

--- a/docs/TUTORIAL_BEGINNER_4_RECIPE.md
+++ b/docs/TUTORIAL_BEGINNER_4_RECIPE.md
@@ -41,6 +41,18 @@ eighteen months.* You will not remember it — but this recipe file will.
 </div>
 </div>
 
+```{tip}
+**Why not just score surveys in the original spreadsheet?** Adapted from the
+*PRISM without Panic* guide (ANC Salzburg). In a spreadsheet, raw answers
+and score formulas often live in the same file — easy to overwrite a
+formula, change a value by accident, or lose track of how a score was
+calculated. In PRISM, the raw questionnaire data stays completely separate
+from the scoring instructions, which are saved as a recipe: a file that can
+be checked, edited, reused, and re-run without touching the original survey
+data. If a scoring rule needs correcting later, you fix the recipe and
+recompute — the raw responses are never at risk.
+```
+
 ## 1. Open Recipe Builder
 
 ![PRISM Studio Recipe Builder screen](_static/screenshots/prism-studio-recipe-builder.png)
@@ -49,6 +61,9 @@ eighteen months.* You will not remember it — but this recipe file will.
 
 Set **Modality** to `survey`, then pick **Template**: `wellbeing` — the one
 you saved into the project in [Chapter 3](TUTORIAL_BEGINNER_3_SURVEY_IMPORT.md).
+Check **Include official library** if you don't see it — this widens the
+dropdown to templates you haven't used in this project yet, not just ones
+already imported.
 
 ## 3. Skip reverse coding
 
@@ -71,6 +86,21 @@ wellbeing) — so leave this panel empty.
 
 You don't need `Transforms.Derived` here — a single summed total doesn't
 need an intermediate helper computation.
+
+```{note}
+**What's "Min valid"?** Adapted from *PRISM without Panic* (ANC Salzburg).
+It controls how PRISM handles missing data when computing a score. Say a
+scale has 9 items: with Min valid off, the score is computed no matter how
+many items are missing. Set to 9, PRISM only computes it when all 9 have
+valid answers. Set to 7, it still computes with at least 7 of 9 answered.
+Leave it off for this tutorial's 5-item scale (no missing data in the
+example file) — for your own instruments, check the questionnaire's manual
+before deciding on a value.
+```
+
+You can click **Preview JSON** at any point to see the recipe's current
+`Scores[]` block as it will be saved, without a server round-trip — useful
+for a quick sanity check before you actually click Save.
 
 ## 5. Skip variations
 
@@ -141,17 +171,30 @@ The formula is safely written down now. Chapter 5 checks whether everything
 
 ## Common mistakes
 
-- **Item name mismatches** — the item names in the recipe must exactly match
-  the template's `ItemID`s (`WB01`-`WB05`); a typo produces a save-time
-  item-reference error, not a silent skip.
-- **Forgetting Range** — the schema requires a `Range` on every `Scores`
-  entry; derive it from the item scale rather than leaving it blank or
-  copying an unrelated instrument's numbers.
-- **Running the recipe before survey data exists** — Analysis Output has
-  nothing to compute against if you skipped Chapter 3; import the survey
-  data first.
-- **Expecting Recipe Builder itself to produce output** — saving a recipe
-  and running it are two different pages; Save only writes the definition.
+```{warning}
+**Item name mismatches.** The item names in the recipe must exactly match
+the template's `ItemID`s (`WB01`-`WB05`); a typo produces a save-time
+item-reference error, not a silent skip.
+```
+
+```{warning}
+**Forgetting Range.** The schema requires a `Range` on every `Scores`
+entry; derive it from the item scale rather than leaving it blank or
+copying an unrelated instrument's numbers.
+```
+
+```{warning}
+**Running the recipe before survey data exists.** Analysis Output has
+nothing to compute against if you skipped Chapter 3; import the survey
+data first.
+```
+
+```{note}
+**Expecting Recipe Builder itself to produce output.** Saving a recipe and
+running it are two different pages; Save only writes the definition —
+Preview JSON lets you sanity-check that definition before you save, but
+neither one runs the recipe against your data.
+```
 
 ## What's next
 

--- a/docs/TUTORIAL_BEGINNER_4_RECIPE.md
+++ b/docs/TUTORIAL_BEGINNER_4_RECIPE.md
@@ -6,7 +6,7 @@ summary score per participant. Recipe Builder only creates and saves the
 scoring definition; actually running it against your data happens on a
 separate page, covered in step 5 below.
 
-**Time:** ~15 minutes. **Outcome:** a saved scoring recipe for the
+**Time:** ~20 minutes. **Outcome:** a saved scoring recipe for the
 `wellbeing` survey, and a computed total score for every participant.
 
 <div class="prism-persona-note" data-persona-note>

--- a/docs/TUTORIAL_BEGINNER_5_VALIDATOR.md
+++ b/docs/TUTORIAL_BEGINNER_5_VALIDATOR.md
@@ -5,9 +5,9 @@ This is about running PRISM's built-in checks against `wellbeing_study` and
 learning to read what they report — not about fixing every possible finding,
 which will vary by project.
 
-**Time:** ~15 minutes. **Outcome:** a validation run against
-`wellbeing_study`, and enough understanding of the results to know what to
-do next.
+**Time:** ~20 minutes. **Outcome:** a validation run against
+`wellbeing_study`, hands-on experience causing and clearing a real error,
+and enough understanding of the results to know what to do next.
 
 <div class="prism-persona-note" data-persona-note>
 <p class="prism-persona-note-empty" data-persona-empty>Picked a persona on the <a href="TUTORIAL_BEGINNER.html#pick-a-reason-to-be-here">intro page</a>? This note speaks to it.</p>
@@ -57,11 +57,18 @@ Validation (PRISM + BIDS)** — you don't need to opt in to get BIDS checks,
 this is already the default. The one thing worth knowing about now:
 **Show BIDS Warnings** is off by default, so a first run's warning count
 undercounts BIDS-side warnings specifically; PRISM warnings are unaffected.
+Two other fields live here if you ever need them: **Schema Version**
+(defaults to `stable` — leave it unless you specifically need an older
+schema) and **Template Library Root** (optional — validation auto-detects
+your project's library by default).
 
 ## 3. Start Validation
 
 Click **Start Validation**. A progress panel appears, then you land on the
-results page automatically.
+results page automatically. For a project this small the run finishes in
+seconds, but for a large dataset the panel also offers **Pause Updates**
+(stops the live progress polling, not the validation run itself — resume
+with **Resume Updates**) and **Cancel Validation**.
 
 ## 4. Read the results
 
@@ -94,7 +101,47 @@ The full catalog, with fix hints for every code, is in
 [Error Codes](ERROR_CODES.md) — every finding in the results also links
 straight to its entry there.
 
-## 5. Fix and re-validate
+```{note}
+**If you skipped Chapter 4:** you'll also see a warning here — "Missing
+survey recipes for dataset-used surveys" — pointing at `wellbeing` having
+no saved recipe yet. That's the Validator noticing the same gap Chapter 4
+fills; it isn't a sign anything earlier in this tutorial went wrong.
+```
+
+## 5. See an error, then clear it
+
+Rather than describe error codes in the abstract, it's worth actually
+causing and fixing one. Survey Convert (Chapter 3) writes one shared JSON
+sidecar for the whole `wellbeing` survey at the project root —
+`task-wellbeing_survey.json` — rather than one per participant, because
+every `sub-*_task-wellbeing_survey.tsv` inherits it (BIDS's inheritance
+principle). That makes it an easy, safe, single-file way to see `PRISM201`
+in action:
+
+1. In your project folder, rename `task-wellbeing_survey.json` to
+   `task-wellbeing_survey.json.bak` (adding a suffix, so nothing is
+   deleted).
+2. Click **Re-validate**. Every `wellbeing` survey file (20 of them, one
+   per participant, if you're following along with the tutorial's data)
+   now has no sidecar to inherit from, and reports as a `PRISM201` error:
+   "Missing sidecar for `<file>.tsv`."
+3. Rename the file back to `task-wellbeing_survey.json` and **Re-validate**
+   again. The 20 errors should be gone.
+
+```{tip}
+`PRISM201` is one of only three codes that are currently **auto-fixable**
+from the CLI (`PRISM001`, `PRISM201`, `PRISM501` — see
+[Error Codes](ERROR_CODES.md)). If you'd rather test that path than rename
+the file back by hand: with the sidecar still missing, run
+`prism-validator /path/to/wellbeing_study --fix --dry-run` and read the
+planned actions before applying anything for real. Note it doesn't restore
+your original root sidecar — it creates a fresh, minimal per-participant
+stub `.json` next to each `.tsv` instead, which is a valid but different
+structure than the one you started with. For this exercise, renaming the
+file back is simpler and gets you back to exactly where you were.
+```
+
+## 6. Fix and re-validate
 
 Use the **Re-validate** button in the action bar to rerun without starting
 over from the Projects page. Repeat until the findings that matter to you
@@ -117,17 +164,25 @@ prism-validator /path/to/wellbeing_study --fix
 
 ## Common mistakes
 
-- **Narrowing to PRISM Only or BIDS Only and thinking that's the full
-  picture** — Full Validation is the default and covers both; only narrow
-  scope deliberately, not by accident while exploring Advanced Options.
-  Something like a survey conversion issue only shows up as a valid file
-  under BIDS-Only mode.
-- **Treating a first run's error count as a failure** — it's expected the
-  first time through; re-validate after each fix rather than expecting zero
-  findings on the first attempt.
-- **Missing BIDS warnings because "Show BIDS Warnings" is off** — turn it on
-  in Advanced Options if you want the complete warning picture, not just
-  PRISM-side warnings.
+```{warning}
+**Narrowing to PRISM Only or BIDS Only and thinking that's the full
+picture.** Full Validation is the default and covers both; only narrow
+scope deliberately, not by accident while exploring Advanced Options.
+Something like a survey conversion issue only shows up as a valid file
+under BIDS-Only mode.
+```
+
+```{note}
+**Treating a first run's error count as a failure.** It's expected the
+first time through; re-validate after each fix rather than expecting zero
+findings on the first attempt.
+```
+
+```{warning}
+**Missing BIDS warnings because "Show BIDS Warnings" is off.** Turn it on
+in Advanced Options if you want the complete warning picture, not just
+PRISM-side warnings.
+```
 
 <div class="prism-persona-note" data-persona-note>
 <p class="prism-persona-note-empty" data-persona-empty>Picked a persona on the <a href="TUTORIAL_BEGINNER.html#pick-a-reason-to-be-here">intro page</a>? This note speaks to it.</p>

--- a/docs/TUTORIAL_BEGINNER_6_EXISTING_BIDS.md
+++ b/docs/TUTORIAL_BEGINNER_6_EXISTING_BIDS.md
@@ -1,6 +1,8 @@
 # Chapter 6: Enrich an Existing BIDS Dataset
 
-**Time:** ~15 minutes | **Outcome:** a BIDS dataset enriched with PRISM participant and behavioral metadata
+**Time:** ~30 minutes (most of it is the dataset download) | **Outcome:** a
+real published BIDS dataset, cloned and initialized without a manual
+terminal step, enriched with PRISM participant and behavioral metadata
 
 ## Why enrich existing datasets?
 
@@ -43,98 +45,141 @@ still being able to work with it.
 
 ## Prerequisites
 
-You need a BIDS dataset to work with. We'll use a real one from OpenNeuro: **ds003138** (a small neuroimaging study). You have two ways to get it:
+You need a BIDS dataset to work with. We'll use a real one from OpenNeuro:
+**ds003138**, a small structural-imaging study of slackline training
+(coincidentally from the same lab that maintains PRISM) — 52 subjects,
+3 sessions each, MRI data only. It already ships with a `participants.tsv`
+(age/sex/group), but nothing else — no survey or behavioral data — which is
+exactly the kind of gap this chapter is about filling in.
 
-### Option A: DataLad (recommended, smaller download)
+This time, PRISM Studio can fetch the dataset itself — no separate terminal
+clone needed. That said, it still calls DataLad under the hood for an
+OpenNeuro dataset like this one, so DataLad and `git-annex` need to be
+installed first; see [DATALAD](DATALAD.md) if you don't have them yet (all
+major OS supported). If you'd rather clone it yourself ahead of time, the
+old two-step path (`datalad install
+https://github.com/OpenNeuroDatasets/ds003138.git`, or a `git clone
+--filter=blob:none --sparse` + `sparse-checkout` to skip the `.nii.gz`
+files) still works — just point **Init PRISM on BIDS Dataset**'s **BIDS
+Dataset Root** at the resulting folder instead of using the remote-URL
+fields below.
 
-DataLad lets you clone only the metadata and structure, not the large MRI files. If you don't have DataLad installed yet, see [DATALAD](DATALAD.md) for installation instructions (all major OS supported).
+## Init PRISM on the dataset
 
-Once installed:
+From the Studio landing page, select **Create or Open a Project** to reach
+the **Projects** page — same as [Chapter 1](TUTORIAL_BEGINNER_1_NEW_PROJECT.md),
+except this time use the **Init PRISM on BIDS Dataset** card instead of
+**Create New Project**. This is the one that matters for an existing
+dataset: it only adds the PRISM files a BIDS dataset doesn't already have
+(`project.json`, `.prismrc.json`, etc.) and never overwrites anything
+that's already there — unlike **Open Existing Project**, which requires a
+`project.json` to already exist and will reject a plain BIDS clone outright
+since it doesn't have one yet.
 
-```bash
-datalad install https://github.com/OpenNeuroDatasets/ds003138.git
-cd ds003138
+- **Git / DataLad URL**: `https://github.com/OpenNeuroDatasets/ds003138.git`
+- **Clone Destination**: an empty folder, e.g. `~/prism_projects/ds003138`
+- Leave the other fields at their defaults — PRISM recognizes the
+  `OpenNeuroDatasets` URL pattern and installs it with DataLad
+  automatically, whether or not you check **Use DataLad version control**.
+- Click **Init PRISM on This Dataset**.
+
+```{note}
+**"No participants.tsv yet" doesn't always hold — and that's fine.**
+Earlier drafts of this chapter assumed the example dataset had no
+`participants.tsv`. ds003138 actually already has one, with real age/sex/
+group data for all 52 subjects — a very common real-world case. Chapter 2's
+Merge workflow (Step 1 below) is exactly the tool for extending a
+`participants.tsv` that already exists, rather than starting from empty.
 ```
 
-This creates a `ds003138/` folder with the BIDS structure and metadata, but no .nii.gz files.
+PRISM streams progress as it clones and initializes, then loads the project
+automatically. You'll see:
+- `dataset_description.json` and the existing `sub-*` folders, untouched
+- `participants.tsv` already populated (age, sex, group)
+- No survey or behavioral data anywhere — that's what Step 2 adds
 
-### Option B: Git sparse-checkout (no DataLad required)
-
-If DataLad installation is tricky on your system, clone the repository and skip binary files:
-
-```bash
-git clone --filter=blob:none --sparse https://github.com/OpenNeuroDatasets/ds003138.git
-cd ds003138
-git sparse-checkout add '/*' '!**/*.nii.gz' '!**/*.nii' '!.git/annex'
+```{note}
+**Why did PRISM mention un-annexing files?** If you used the DataLad path,
+check the Init log for a line like "Un-annexed N text-format file(s) that
+arrived already tracked by git-annex in the source dataset." OpenNeuro's
+DataLad datasets sometimes have small text-format files (like
+`participants.tsv` itself) stored as git-annex symlinks alongside the large
+binary MRI data. PRISM's policy is that text/small-codebook files should
+never be annexed — they need to be directly readable and diffable — so
+Init automatically un-annexes any that arrive that way, without you having
+to notice or fix it yourself.
 ```
 
-Either way, you now have a local BIDS dataset with the structure intact.
+## Step 1: extend the existing participants.tsv with Merge
 
-## Open the dataset in PRISM
+`participants.tsv` already exists here, so this is Chapter 2's **Merge**
+workflow in a real setting, not the fresh-create path — a good chance to
+use it for something other than a made-up exercise.
 
-Launch PRISM Studio and open the `ds003138` folder as a project:
+Pretend you've been handed a handedness assessment for three of the
+subjects. Create a small spreadsheet, `handedness_update.xlsx`:
 
-**Home** → **Open Project** → navigate to your `ds003138` folder → **Open**.
+| participant_id | handedness |
+|---|---|
+| sub-82KK02101 | right |
+| sub-82KK02102 | left |
+| sub-82KK02103 | right |
 
-PRISM recognizes it as an existing BIDS project and loads the metadata. You'll see:
-- `dataset_description.json` already present
-- Existing subject folders (`sub-001`, `sub-002`, etc.)
-- No `participants.tsv` yet (or an incomplete one) — that's what we'll add
+(Use three real subject IDs from your cloned dataset — check any three
+`sub-*` folder names if you're not using ds003138.)
 
-## Step 1: Add participant demographic data
+1. **Converter** → **Sociodemographics** tab. Since `participants.tsv`
+   already exists, you'll be asked to choose a workflow: pick **Merge**.
+2. Upload `handedness_update.xlsx`, confirm `participant_id` as the ID
+   column, and click **Preview Merge**.
+3. The Merge Summary should show `3 matched`, `3 filled values` (one new
+   `handedness` value per row), `0 new participants`, `0 conflicts` — this
+   file only adds a column that didn't exist before, so there's nothing to
+   conflict with.
+4. Click **Apply Merge**.
 
-Just like in [Chapter 2](TUTORIAL_BEGINNER_2_PARTICIPANTS.md), we'll use the Converter to add participant metadata. But this time, we're enriching an existing dataset instead of creating one from scratch.
+**Expected outcome:** `participants.tsv` still has all 52 original rows,
+now with a `handedness` column that's populated for the three subjects you
+provided and empty for the other 49 — Merge only fills in what you gave it,
+exactly as it did in Chapter 2.
 
-**Converter** → **Participants** tab → **Load File**.
+## Step 2: add behavioral data
 
-Create a simple spreadsheet with fake demographic data for three subjects. Save it as `sample_participants.xlsx`:
+ds003138 genuinely has no survey/behavioral data — this is the real
+enrichment opportunity, using the same Survey Import workflow from
+[Chapter 3](TUTORIAL_BEGINNER_3_SURVEY_IMPORT.md). ds003138 has three
+sessions per subject (`ses-1`, `ses-2`, `ses-3`); pretend these three
+subjects completed a brief wellbeing check-in at `ses-1`.
 
-| participant_id | age | sex | group |
-|---|---|---|---|
-| 001 | 28 | M | control |
-| 002 | 35 | F | treatment |
-| 003 | 31 | M | control |
+Create a fake survey file, `sample_survey.xlsx`:
 
-(Use the IDs that match your dataset's existing subjects, e.g., `001`, `002`, `003` if your dataset has `sub-001`, `sub-002`, `sub-003`.)
+| participant_id | session | WB01 | WB02 | WB03 | WB04 | WB05 |
+|---|---|---|---|---|---|---|
+| sub-82KK02101 | 1 | 4 | 5 | 3 | 4 | 4 |
+| sub-82KK02102 | 1 | 3 | 4 | 4 | 3 | 3 |
+| sub-82KK02103 | 1 | 5 | 5 | 4 | 5 | 4 |
 
-**Load File** → select `sample_participants.xlsx` → map columns:
-- `participant_id` → Participant ID column
-- `age` → Age
-- `sex` → Sex
-- `group` → Group (or use the generic "Custom field" option)
+This reuses the `wellbeing` template from Chapter 3 (all five items, since
+the template expects exactly `WB01`-`WB05` — see Chapter 3's Common
+Mistakes if you want to try fewer items instead, which needs a different
+template).
 
-**Preview** → confirm the mapping → **Save**.
+1. **Converter** → **Survey** tab → select `sample_survey.xlsx`.
+2. **Participant ID Column**: `participant_id`. **Session Column**:
+   `session`. **Session ID**: `1` (matching `ses-1`).
+3. **Preview** — confirm 3 participants found, task `wellbeing`, no missing
+   items.
+4. **Convert**.
 
-PRISM writes `participants.tsv` and `participants.json` into your dataset. If `participants.tsv` already existed, PRISM merges your new data with the existing rows (matching by ID).
+PRISM creates one `.tsv` per subject
+(`sub-82KK02101/ses-1/survey/sub-82KK02101_ses-1_task-wellbeing_survey.tsv`,
+etc.) plus the single shared root-level `task-wellbeing_survey.json`
+sidecar — same structure as Chapter 3, just written into an existing
+dataset instead of a fresh one.
 
-**Expected outcome:** `participants.tsv` now has 3 rows with demographics.
-
-## Step 2: Add behavioral data
-
-Now pretend these three subjects completed a brief survey (e.g., a mood or wellbeing questionnaire). We'll add it using the same Survey import workflow from [Chapter 3](TUTORIAL_BEGINNER_3_SURVEY_IMPORT.md).
-
-Create a fake survey file (`sample_survey.xlsx`):
-
-| participant_id | task | WB01 | WB02 | WB03 |
-|---|---|---|---|---|
-| 001 | wellbeing | 4 | 5 | 3 |
-| 002 | wellbeing | 3 | 4 | 4 |
-| 003 | wellbeing | 5 | 5 | 4 |
-
-Where `WB01`, `WB02`, `WB03` are item responses (fake Likert scores).
-
-**Converter** → **Survey** tab → **Load File** → select `sample_survey.xlsx`.
-
-Confirm:
-- Participant ID column: `participant_id`
-- Survey item columns: `WB01`, `WB02`, `WB03`
-- Task name: `wellbeing` (or match the existing task label in your dataset)
-
-**Preview** → **Save**.
-
-PRISM creates survey response files (`sub-001_task-wellbeing_survey.tsv`, etc.) in the respective subject folders, and adds a survey sidecar JSON for metadata.
-
-**Expected outcome:** Survey files now sit alongside the MRI data in each subject folder.
+**Expected outcome:** survey files now sit alongside the MRI data, only for
+the three subjects and one session you provided — everyone else's folders
+are untouched.
 
 ## Step 3: Validate
 
@@ -142,22 +187,33 @@ Run the Validator to check that your enriched dataset is still BIDS-compliant:
 
 **Validator** → confirm the project is selected → **Start Validation**.
 
-You should see:
-- Mostly green (no errors for the files you added)
-- Possible suggestions (e.g., "consider adding task description JSON")
-- No new warnings introduced by your metadata
-
-If errors appear, they're usually about existing MRI data or missing sidecars — not your fault. You've successfully enriched the dataset without breaking it.
+You should see mostly green: no errors for the `handedness` column or the
+survey files you just added, since both went through the same
+Merge/Convert paths already validated in Chapters 2 and 3. If the standard
+BIDS/MRI side of ds003138 itself surfaces findings (some real-world
+datasets do, even published ones), those predate anything you did here —
+the ones worth checking are new findings on the *files you touched*:
+`participants.tsv`/`.json` and the `sub-82KK02101` (etc.) survey files.
+Nothing about enriching an existing dataset changes how you read results —
+see [Chapter 5](TUTORIAL_BEGINNER_5_VALIDATOR.md) if you need the refresher.
 
 ## What you just did
 
-You took a published BIDS dataset and added two layers of PRISM metadata:
-1. Participant demographics (age, sex, group)
-2. Behavioral survey data
+You took a published BIDS dataset — one you didn't create, with data
+already in it — and:
+1. Initialized PRISM on it directly from its remote URL, without a manual
+   terminal clone step.
+2. Extended its existing `participants.tsv` with Merge, rather than
+   overwriting it.
+3. Added behavioral survey data it never had, using the same Survey Import
+   workflow as Chapter 3.
+4. Validated the result the same way as Chapter 5.
 
-The workflow was identical to building a dataset from scratch in Chapters 1–5. The only difference: you started with existing MRI/BIDS structure instead of an empty folder.
-
-This is the real-world value of PRISM: it works *on top* of BIDS, not instead of it. Whether you're creating a dataset or enhancing one, the tools stay the same.
+The tools were identical to Chapters 1–5 throughout — the only difference
+was starting from an existing BIDS structure with its own data already in
+it, instead of an empty folder. That's the real-world value of PRISM: it
+works *on top* of BIDS, not instead of it, whether you're building a
+dataset from scratch or enriching someone else's.
 
 <div class="prism-persona-note" data-persona-note>
 <p class="prism-persona-note-empty" data-persona-empty>Picked a persona on the <a href="TUTORIAL_BEGINNER.html#pick-a-reason-to-be-here">intro page</a>? This closing note speaks to it.</p>

--- a/docs/studio/converter_participants.md
+++ b/docs/studio/converter_participants.md
@@ -34,6 +34,22 @@ attach NeuroBagel-style term mappings and `Levels` descriptions to `participants
 Saving this annotation is optional ("Save Draft Metadata (Optional)") — unsaved edits
 in that panel are still applied when you create the files in Step 3.
 
+## When participant files already exist: Replace / Modify / Merge
+
+If `participants.tsv` already exists in the project, the tab asks you to choose a
+workflow before Review/Save unlock:
+
+- **Replace** — the imported file becomes the new source of truth; current
+  `participants.tsv`/`.json` are fully replaced.
+- **Modify** — the current files stay authoritative; edit them (e.g. their metadata)
+  in place without importing a new source file.
+- **Merge** — safely combines an imported table into the current files: it fills
+  *missing* values, adds new participants, and adds new columns. Any incoming
+  non-empty value that differs from an existing one is reported as a **conflict**,
+  and Apply Merge is blocked until every conflict is resolved (fix the source and
+  re-preview) — Merge never silently overwrites existing data. Use **Download
+  Conflict Report** to see exactly what disagreed.
+
 ## Step 3 — Create Participant Files
 
 Writes `participants.tsv` and `participants.json` together — every conversion path

--- a/examples/workshop/exercise_1_raw_data/raw_data/wellbeing.tsv
+++ b/examples/workshop/exercise_1_raw_data/raw_data/wellbeing.tsv
@@ -1,11 +1,21 @@
-participant_id	session	age	sex	education	handedness	WB01	WB02	WB03	WB04	WB05	completion_date
-DEMO001	baseline	28	2	4	1	4	4	2	3	4	2025-01-15
-DEMO002	baseline	34	1	5	1	3	3	3	3	3	2025-01-16
-DEMO003	baseline	22	2	3	1	5	5	1	5	5	2025-01-17
-DEMO004	baseline	45	1	6	2	2	2	4	2	2	2025-01-18
-DEMO005	baseline	31	2	4	1	4	3	2	4	3	2025-01-19
-DEMO006	baseline	27	4	5	1	3	4	3	3	4	2025-01-20
-DEMO007	baseline	52	1	4	1	4	4	2	4	4	2025-01-21
-DEMO008	baseline	19	2	2	2	2	3	4	2	3	2025-01-22
-DEMO009	baseline	38	1	5	1	5	4	1	5	4	2025-01-23
-DEMO010	baseline	41	2	6	2	3	3	3	3	3	2025-01-24
+participant_id	session	age	sex	education	handedness	WB01	WB02	WB03	WB04	WB05	completion_date	sleep
+DEMO001	baseline	28	2	4	1	4	4	2	3	4	2025-01-15	1
+DEMO002	baseline	34	1	5	1	3	3	3	3	3	2025-01-16	1
+DEMO003	baseline	22	2	3	1	5	5	1	5	5	2025-01-17	1
+DEMO004	baseline	45	1	6	2	2	2	4	2	2	2025-01-18	2
+DEMO005	baseline	31	2	4	1	4	3	2	4	3	2025-01-19	1
+DEMO006	baseline	27	4	5	1	3	4	3	3	4	2025-01-20	1
+DEMO007	baseline	52	1	4	1	4	4	2	4	4	2025-01-21	1
+DEMO008	baseline	19	2	2	2	2	3	4	2	3	2025-01-22	2
+DEMO009	baseline	38	1	5	1	5	4	1	5	4	2025-01-23	1
+DEMO010	baseline	41	2	6	2	3	3	3	3	3	2025-01-24	2
+DEMO011	baseline	28	2	4	1	4	4	2	3	4	2025-01-15	1
+DEMO012	baseline	34	1	5	1	3	3	3	3	3	2025-01-16	1
+DEMO013	baseline	22	2	3	1	5	5	1	5	5	2025-01-17	1
+DEMO014	baseline	45	1	6	2	2	2	4	2	2	2025-01-18	2
+DEMO015	baseline	31	2	4	1	4	3	2	4	3	2025-01-19	1
+DEMO016	baseline	27	4	5	1	3	4	3	3	4	2025-01-20	1
+DEMO017	baseline	52	1	4	1	4	4	2	4	4	2025-01-21	1
+DEMO018	baseline	19	2	2	2	2	3	4	2	3	2025-01-22	2
+DEMO019	baseline	38	1	5	1	5	4	1	5	4	2025-01-23	1
+DEMO020	baseline	41	2	6	2	3	3	3	3	3	2025-01-24	2

--- a/tests/test_cli_survey_commands_remaining.py
+++ b/tests/test_cli_survey_commands_remaining.py
@@ -609,7 +609,7 @@ class TestCmdSurveyConvert:
     def test_success_basic(self, tmp_path, monkeypatch, capsys):
         self._plain_library(tmp_path)
         monkeypatch.setattr(
-            "src.converters.survey.convert_survey_xlsx_to_prism_dataset",
+            "src.converters.survey.convert_survey_file_to_prism_dataset",
             lambda **kw: _FakeResult(),
         )
         cmd_survey_convert(_convert_args(tmp_path))
@@ -623,7 +623,7 @@ class TestCmdSurveyConvert:
             raise RuntimeError("bad convert")
 
         monkeypatch.setattr(
-            "src.converters.survey.convert_survey_xlsx_to_prism_dataset", _boom
+            "src.converters.survey.convert_survey_file_to_prism_dataset", _boom
         )
         with pytest.raises(SystemExit) as exc_info:
             cmd_survey_convert(_convert_args(tmp_path))
@@ -633,7 +633,7 @@ class TestCmdSurveyConvert:
     def test_with_overrides_offsets_and_warnings(self, tmp_path, monkeypatch, capsys):
         self._plain_library(tmp_path)
         monkeypatch.setattr(
-            "src.converters.survey.convert_survey_xlsx_to_prism_dataset",
+            "src.converters.survey.convert_survey_file_to_prism_dataset",
             lambda **kw: _FakeResult(
                 session_column="session",
                 run_column="run",
@@ -665,7 +665,7 @@ class TestCmdSurveyConvert:
             return _FakeResult()
 
         monkeypatch.setattr(
-            "src.converters.survey.convert_survey_xlsx_to_prism_dataset", _fake_convert
+            "src.converters.survey.convert_survey_file_to_prism_dataset", _fake_convert
         )
         project_file = tmp_path / "project.json"
         project_file.write_text("{}")
@@ -763,7 +763,7 @@ class TestCmdSurveyConvert:
             ],
         }
         monkeypatch.setattr(
-            "src.converters.survey.convert_survey_xlsx_to_prism_dataset",
+            "src.converters.survey.convert_survey_file_to_prism_dataset",
             lambda **kw: _FakeResult(dry_run_preview=preview),
         )
         cmd_survey_convert(_convert_args(tmp_path, dry_run=True))
@@ -794,7 +794,7 @@ class TestCmdSurveyConvert:
             "files_to_create": [],
         }
         monkeypatch.setattr(
-            "src.converters.survey.convert_survey_xlsx_to_prism_dataset",
+            "src.converters.survey.convert_survey_file_to_prism_dataset",
             lambda **kw: _FakeResult(dry_run_preview=preview),
         )
         cmd_survey_convert(_convert_args(tmp_path, dry_run=True))
@@ -813,7 +813,7 @@ class TestCmdSurveyConvert:
             lambda data, lang, fallback_langs: {"compiled": True},
         )
         monkeypatch.setattr(
-            "src.converters.survey.convert_survey_xlsx_to_prism_dataset",
+            "src.converters.survey.convert_survey_file_to_prism_dataset",
             lambda **kw: _FakeResult(),
         )
         cmd_survey_convert(_convert_args(tmp_path, library=str(library)))
@@ -829,7 +829,7 @@ class TestCmdSurveyConvert:
         (lib_dir / "survey-pss.json").write_text(json.dumps({"pss01": {}}))
         monkeypatch.setattr(survey_cli, "_APP_ROOT", app_root)
         monkeypatch.setattr(
-            "src.converters.survey.convert_survey_xlsx_to_prism_dataset",
+            "src.converters.survey.convert_survey_file_to_prism_dataset",
             lambda **kw: _FakeResult(),
         )
         cmd_survey_convert(_convert_args(tmp_path, library=None))
@@ -850,7 +850,7 @@ class TestCmdSurveyConvert:
             lambda data, lang, fallback_langs: {"compiled": True},
         )
         monkeypatch.setattr(
-            "src.converters.survey.convert_survey_xlsx_to_prism_dataset",
+            "src.converters.survey.convert_survey_file_to_prism_dataset",
             lambda **kw: _FakeResult(),
         )
         cmd_survey_convert(_convert_args(tmp_path, library=None))
@@ -866,7 +866,7 @@ class TestCmdSurveyConvert:
         (lib_dir / "survey-pss.json").write_text(json.dumps({"pss01": {}}))
         monkeypatch.setattr(survey_cli, "_APP_ROOT", app_root)
         monkeypatch.setattr(
-            "src.converters.survey.convert_survey_xlsx_to_prism_dataset",
+            "src.converters.survey.convert_survey_file_to_prism_dataset",
             lambda **kw: _FakeResult(),
         )
         cmd_survey_convert(_convert_args(tmp_path, library=None))

--- a/tests/test_converter_project_save_contracts.py
+++ b/tests/test_converter_project_save_contracts.py
@@ -284,7 +284,7 @@ def test_survey_convert_rejects_stale_project_path(tmp_path, monkeypatch):
         )
 
     monkeypatch.setattr(
-        survey, "convert_survey_xlsx_to_prism_dataset", _unexpected_convert
+        survey, "convert_survey_file_to_prism_dataset", _unexpected_convert
     )
 
     with app.test_client() as client:

--- a/tests/test_converter_workflow_wiring.py
+++ b/tests/test_converter_workflow_wiring.py
@@ -1617,8 +1617,8 @@ class TestConverterWorkflowWiring(unittest.TestCase):
         environment_content = ENVIRONMENT_TEMPLATE.read_text(encoding="utf-8")
         eyetracking_content = EYETRACKING_TEMPLATE.read_text(encoding="utf-8")
 
-        self.assertIn('class="form-control" type="file" id="convertExcelFile"', survey_content)
-        self.assertNotIn('visually-hidden" type="file" id="convertExcelFile"', survey_content)
+        self.assertIn('class="form-control" type="file" id="convertSurveyFile"', survey_content)
+        self.assertNotIn('visually-hidden" type="file" id="convertSurveyFile"', survey_content)
 
         self.assertIn('class="form-control" type="file" id="biometricsDataFile"', biometrics_content)
         self.assertNotIn('visually-hidden" type="file" id="biometricsDataFile"', biometrics_content)
@@ -2019,7 +2019,7 @@ class TestConverterWorkflowWiring(unittest.TestCase):
             import_form_state_content,
         )
         self.assertIn(
-            "if (clearSelectedInput) {\n            setConvertServerFilePath('');\n            if (convertExcelFile) {\n                convertExcelFile.value = '';\n            }\n        }\n        surveySourcedataQuickSelectController.clearSelectedFile();",
+            "if (clearSelectedInput) {\n            setConvertServerFilePath('');\n            if (convertSurveyFile) {\n                convertSurveyFile.value = '';\n            }\n        }\n        surveySourcedataQuickSelectController.clearSelectedFile();",
             import_form_state_content,
         )
 

--- a/tests/test_file_picker_responsive_wiring.py
+++ b/tests/test_file_picker_responsive_wiring.py
@@ -45,7 +45,7 @@ class TestFilePickerResponsiveWiring(unittest.TestCase):
     def test_direct_picker_templates_use_shared_picker_group_class(self):
         templates = {
             CONVERTER_PARTICIPANTS_TEMPLATE: ["participantsChooseFileBtn"],
-            CONVERTER_SURVEY_TEMPLATE: ["convertExcelFile", "convertIdMapFile"],
+            CONVERTER_SURVEY_TEMPLATE: ["convertSurveyFile", "convertIdMapFile"],
             CONVERTER_BIOMETRICS_TEMPLATE: ["biometricsDataFile"],
             CONVERTER_ENVIRONMENT_TEMPLATE: ["envDataFile"],
             CONVERTER_PHYSIO_TEMPLATE: ["physioBatchFiles", "physioBatchFolder"],

--- a/tests/test_hostile_demo_pipeline.py
+++ b/tests/test_hostile_demo_pipeline.py
@@ -16,7 +16,7 @@ import pytest
 from src.bids_entity_rewriter import BidsEntityRewriter
 from src.converters.biometrics import convert_biometrics_table_to_prism_dataset
 from src.converters.file_reader import read_tabular_file
-from src.converters.survey import convert_survey_xlsx_to_prism_dataset
+from src.converters.survey import convert_survey_file_to_prism_dataset
 from src.hostile_demo_generator import (
     NON_MRI_DOMAINS,
     assert_text_files_never_annexed,
@@ -496,8 +496,8 @@ def test_full_non_mri_sweep_with_and_without_datalad(tmp_path: Path, use_datalad
     # generated survey, into the same project root.
     library_dir = project_root / "code" / "library" / "survey"
     survey_result = _run_pipeline_stage(
-        "convert_survey_xlsx_to_prism_dataset",
-        convert_survey_xlsx_to_prism_dataset,
+        "convert_survey_file_to_prism_dataset",
+        convert_survey_file_to_prism_dataset,
         input_path=rawdata / "survey_clean_baseline.csv",
         library_dir=library_dir,
         output_root=project_root,

--- a/tests/test_hostile_survey_pipeline.py
+++ b/tests/test_hostile_survey_pipeline.py
@@ -3,7 +3,7 @@
 
 Exercises the real production functions the Survey Converter and Recipe
 Builder UIs call: SurveyResponsesConverter (via
-convert_survey_xlsx_to_prism_dataset) and compute_survey_recipes.
+convert_survey_file_to_prism_dataset) and compute_survey_recipes.
 """
 
 from __future__ import annotations
@@ -13,7 +13,7 @@ from pathlib import Path
 import pandas as pd
 import pytest
 
-from src.converters.survey import convert_survey_xlsx_to_prism_dataset
+from src.converters.survey import convert_survey_file_to_prism_dataset
 from src.converters.survey_processing import SurveyValueOutOfBoundsError
 from src.hostile_demo_generator import generate_hostile_dataset
 from src.recipe_validation import validate_recipe
@@ -50,7 +50,7 @@ def test_clean_baseline_imports_successfully(tmp_path, library_dir, rawdata_dir)
     out = tmp_path / "out"
     result = _run_pipeline_stage(
         "convert clean baseline",
-        convert_survey_xlsx_to_prism_dataset,
+        convert_survey_file_to_prism_dataset,
         input_path=rawdata_dir / "survey_clean_baseline.csv",
         library_dir=library_dir,
         output_root=out,
@@ -65,7 +65,7 @@ def test_exact_duplicate_rows_error_mode_raises_clean_error(
     tmp_path, library_dir, rawdata_dir
 ):
     with pytest.raises(ValueError, match="Duplicate entries"):
-        convert_survey_xlsx_to_prism_dataset(
+        convert_survey_file_to_prism_dataset(
             input_path=rawdata_dir / "survey_exact_duplicate_rows.csv",
             library_dir=library_dir,
             output_root=tmp_path / "out",
@@ -77,7 +77,7 @@ def test_exact_duplicate_rows_error_mode_raises_clean_error(
 def test_exact_duplicate_rows_keep_first_succeeds(tmp_path, library_dir, rawdata_dir):
     result = _run_pipeline_stage(
         "convert exact duplicates (keep_first)",
-        convert_survey_xlsx_to_prism_dataset,
+        convert_survey_file_to_prism_dataset,
         input_path=rawdata_dir / "survey_exact_duplicate_rows.csv",
         library_dir=library_dir,
         output_root=tmp_path / "out",
@@ -93,7 +93,7 @@ def test_conflicting_duplicate_rows_error_mode_raises_before_picking_an_answer(
     """The two rows disagree on an item value — 'error' must refuse rather
     than silently picking one answer over the other."""
     with pytest.raises(ValueError, match="Duplicate entries"):
-        convert_survey_xlsx_to_prism_dataset(
+        convert_survey_file_to_prism_dataset(
             input_path=rawdata_dir / "survey_conflicting_duplicate_rows.csv",
             library_dir=library_dir,
             output_root=tmp_path / "out",
@@ -107,7 +107,7 @@ def test_conflicting_duplicate_rows_keep_last_resolves_deterministically(
 ):
     result = _run_pipeline_stage(
         "convert conflicting duplicates (keep_last)",
-        convert_survey_xlsx_to_prism_dataset,
+        convert_survey_file_to_prism_dataset,
         input_path=rawdata_dir / "survey_conflicting_duplicate_rows.csv",
         library_dir=library_dir,
         output_root=tmp_path / "out",
@@ -129,7 +129,7 @@ def test_multi_session_same_participant_requires_one_call_per_session(
 
     single_call_result = _run_pipeline_stage(
         "convert multi-session without explicit session=",
-        convert_survey_xlsx_to_prism_dataset,
+        convert_survey_file_to_prism_dataset,
         input_path=source,
         library_dir=library_dir,
         output_root=tmp_path / "out_default",
@@ -145,7 +145,7 @@ def test_multi_session_same_participant_requires_one_call_per_session(
     for session in ("ses-1", "ses-2"):
         _run_pipeline_stage(
             f"convert multi-session with session={session}",
-            convert_survey_xlsx_to_prism_dataset,
+            convert_survey_file_to_prism_dataset,
             input_path=source,
             library_dir=library_dir,
             output_root=tmp_path / "out_per_session",
@@ -162,7 +162,7 @@ def test_multi_session_same_participant_requires_one_call_per_session(
 
 def test_out_of_range_value_raises_structured_error(tmp_path, library_dir, rawdata_dir):
     with pytest.raises(SurveyValueOutOfBoundsError):
-        convert_survey_xlsx_to_prism_dataset(
+        convert_survey_file_to_prism_dataset(
             input_path=rawdata_dir / "survey_out_of_range_value.csv",
             library_dir=library_dir,
             output_root=tmp_path / "out",
@@ -173,7 +173,7 @@ def test_out_of_range_value_raises_structured_error(tmp_path, library_dir, rawda
 def test_missing_cell_converts_without_crashing(tmp_path, library_dir, rawdata_dir):
     result = _run_pipeline_stage(
         "convert missing cell",
-        convert_survey_xlsx_to_prism_dataset,
+        convert_survey_file_to_prism_dataset,
         input_path=rawdata_dir / "survey_missing_cell.csv",
         library_dir=library_dir,
         output_root=tmp_path / "out",
@@ -189,7 +189,7 @@ def test_unmapped_extra_column_is_surfaced_not_dropped_silently(
     confirms the CSV quoting round-trips correctly through the parser."""
     result = _run_pipeline_stage(
         "convert with unmapped column",
-        convert_survey_xlsx_to_prism_dataset,
+        convert_survey_file_to_prism_dataset,
         input_path=rawdata_dir / "survey_unmapped_extra_column.csv",
         library_dir=library_dir,
         output_root=tmp_path / "out",
@@ -212,7 +212,7 @@ def test_mixed_tab_comma_delimiters_known_gap_garbles_one_row(
     out = tmp_path / "out"
     result = _run_pipeline_stage(
         "convert mixed delimiters",
-        convert_survey_xlsx_to_prism_dataset,
+        convert_survey_file_to_prism_dataset,
         input_path=rawdata_dir / "survey_mixed_tab_comma_delimiters.csv",
         library_dir=library_dir,
         output_root=out,
@@ -239,7 +239,7 @@ def test_recipe_computes_correct_scores_in_every_export_format(
     tmp_path, survey_dataset: Path, library_dir, rawdata_dir, out_format: str
 ):
     out = tmp_path / f"out_{out_format}"
-    convert_survey_xlsx_to_prism_dataset(
+    convert_survey_file_to_prism_dataset(
         input_path=rawdata_dir / "survey_clean_baseline.csv",
         library_dir=library_dir,
         output_root=out,
@@ -317,7 +317,7 @@ def test_survey_conversion_rejects_case_only_differing_ids(
     pd.DataFrame(rows).to_csv(collision_csv, index=False)
 
     with pytest.raises(ValueError, match="differ only by case"):
-        convert_survey_xlsx_to_prism_dataset(
+        convert_survey_file_to_prism_dataset(
             input_path=collision_csv,
             library_dir=library_dir,
             output_root=tmp_path / "out",

--- a/tests/test_survey_converter_version_plan_acq.py
+++ b/tests/test_survey_converter_version_plan_acq.py
@@ -16,7 +16,7 @@ import pandas as pd
 from src.converters.survey import (
     _build_task_context_maps,
     _load_and_preprocess_templates,
-    convert_survey_xlsx_to_prism_dataset,
+    convert_survey_file_to_prism_dataset,
 )
 from src.converters.survey_io import _lookup_task_context_value
 from src.converters.survey_templates import _apply_template_version_selection
@@ -504,7 +504,7 @@ post,7,1,23,1,2,2,2,2,2,2,2,2,2,2,2
         encoding="utf-8",
     )
 
-    result = convert_survey_xlsx_to_prism_dataset(
+    result = convert_survey_file_to_prism_dataset(
         input_path=input_path,
         library_dir=library_dir,
         output_root=tmp_path / "out",

--- a/tests/test_survey_preview_regressions.py
+++ b/tests/test_survey_preview_regressions.py
@@ -198,7 +198,7 @@ def test_survey_preview_validation_rerun_keeps_run_column(monkeypatch, tmp_path)
         session["current_project_path"] = str(project_root)
 
         response = handle_api_survey_convert_preview(
-            convert_survey_xlsx_to_prism_dataset=object(),
+            convert_survey_file_to_prism_dataset=object(),
             convert_survey_lsa_to_prism_dataset=object(),
             resolve_effective_library_path=lambda: library_root,
             run_survey_with_official_fallback=fake_run_survey_with_official_fallback,
@@ -285,7 +285,7 @@ def test_survey_preview_validation_skips_per_task_probe_without_manual_review_co
         session["current_project_path"] = str(project_root)
 
         response = handle_api_survey_convert_preview(
-            convert_survey_xlsx_to_prism_dataset=object(),
+            convert_survey_file_to_prism_dataset=object(),
             convert_survey_lsa_to_prism_dataset=object(),
             resolve_effective_library_path=lambda: library_root,
             run_survey_with_official_fallback=fake_run_survey_with_official_fallback,
@@ -385,7 +385,7 @@ def test_survey_preview_uses_project_template_version_overrides_when_request_mis
         session["current_project_path"] = str(project_root)
 
         response = handle_api_survey_convert_preview(
-            convert_survey_xlsx_to_prism_dataset=object(),
+            convert_survey_file_to_prism_dataset=object(),
             convert_survey_lsa_to_prism_dataset=object(),
             resolve_effective_library_path=lambda: library_root,
             run_survey_with_official_fallback=fake_run_survey_with_official_fallback,
@@ -445,7 +445,7 @@ def test_survey_preview_requires_confirmation_for_near_matches(monkeypatch, tmp_
         session["current_project_path"] = str(project_root)
 
         response = handle_api_survey_convert_preview(
-            convert_survey_xlsx_to_prism_dataset=object(),
+            convert_survey_file_to_prism_dataset=object(),
             convert_survey_lsa_to_prism_dataset=object(),
             resolve_effective_library_path=lambda: library_root,
             run_survey_with_official_fallback=fake_run_survey_with_official_fallback,
@@ -531,7 +531,7 @@ def test_survey_preview_passes_selected_near_match_tasks(monkeypatch, tmp_path):
         session["current_project_path"] = str(project_root)
 
         response = handle_api_survey_convert_preview(
-            convert_survey_xlsx_to_prism_dataset=object(),
+            convert_survey_file_to_prism_dataset=object(),
             convert_survey_lsa_to_prism_dataset=object(),
             resolve_effective_library_path=lambda: library_root,
             run_survey_with_official_fallback=fake_run_survey_with_official_fallback,
@@ -607,7 +607,7 @@ def test_survey_preview_accepts_sav_input(monkeypatch, tmp_path):
         session["current_project_path"] = str(project_root)
 
         response = handle_api_survey_convert_preview(
-            convert_survey_xlsx_to_prism_dataset=object(),
+            convert_survey_file_to_prism_dataset=object(),
             convert_survey_lsa_to_prism_dataset=object(),
             resolve_effective_library_path=lambda: library_root,
             run_survey_with_official_fallback=fake_run_survey_with_official_fallback,

--- a/tests/test_survey_value_offsets.py
+++ b/tests/test_survey_value_offsets.py
@@ -527,7 +527,7 @@ def test_survey_preview_returns_value_offset_confirmation_payload(tmp_path):
         session["current_project_path"] = str(project_root)
 
         response = handle_api_survey_convert_preview(
-            convert_survey_xlsx_to_prism_dataset=object(),
+            convert_survey_file_to_prism_dataset=object(),
             convert_survey_lsa_to_prism_dataset=object(),
             resolve_effective_library_path=lambda: library_root,
             run_survey_with_official_fallback=fake_run_survey_with_official_fallback,
@@ -622,7 +622,7 @@ def test_survey_preview_passes_value_offsets_to_converter(tmp_path):
     ):
         session["current_project_path"] = str(project_root)
         response = handle_api_survey_convert_preview(
-            convert_survey_xlsx_to_prism_dataset=object(),
+            convert_survey_file_to_prism_dataset=object(),
             convert_survey_lsa_to_prism_dataset=object(),
             resolve_effective_library_path=lambda: library_root,
             run_survey_with_official_fallback=fake_run_survey_with_official_fallback,
@@ -703,7 +703,7 @@ def test_survey_preview_merges_selected_tasks_filter(tmp_path):
     ):
         session["current_project_path"] = str(project_root)
         response = handle_api_survey_convert_preview(
-            convert_survey_xlsx_to_prism_dataset=object(),
+            convert_survey_file_to_prism_dataset=object(),
             convert_survey_lsa_to_prism_dataset=object(),
             resolve_effective_library_path=lambda: library_root,
             run_survey_with_official_fallback=fake_run_survey_with_official_fallback,
@@ -794,7 +794,7 @@ def test_survey_preview_validate_path_returns_task_review_summary(tmp_path):
     ):
         session["current_project_path"] = str(project_root)
         response = handle_api_survey_convert_preview(
-            convert_survey_xlsx_to_prism_dataset=object(),
+            convert_survey_file_to_prism_dataset=object(),
             convert_survey_lsa_to_prism_dataset=object(),
             resolve_effective_library_path=lambda: library_root,
             run_survey_with_official_fallback=fake_run_survey_with_official_fallback,

--- a/tests/test_unicode_normalization_consistency.py
+++ b/tests/test_unicode_normalization_consistency.py
@@ -64,7 +64,7 @@ def test_survey_normalize_sub_id_consistent_across_unicode_forms() -> None:
     import pandas as pd
 
     from app.src.hostile_demo_generator import build_random_survey_template
-    from src.converters.survey import convert_survey_xlsx_to_prism_dataset
+    from src.converters.survey import convert_survey_file_to_prism_dataset
     from src.utils.io import ensure_dir, write_json
 
     task_name, template, item_codes = build_random_survey_template(seed=1)
@@ -78,7 +78,7 @@ def test_survey_normalize_sub_id_consistent_across_unicode_forms() -> None:
         pd.DataFrame([{"participant_id": name, **{c: 1 for c in item_codes}}]).to_csv(
             data_csv, index=False
         )
-        convert_survey_xlsx_to_prism_dataset(
+        convert_survey_file_to_prism_dataset(
             input_path=data_csv,
             library_dir=library_dir,
             output_root=tmp_path / f"out_{label}",

--- a/tests/test_web_blueprints_conversion.py
+++ b/tests/test_web_blueprints_conversion.py
@@ -431,7 +431,7 @@ class TestSurveyPrepareWorkflowEndpoint(unittest.TestCase):
             "src.web.blueprints.conversion_survey_handlers"
         )
 
-        self.assertTrue(callable(handlers.convert_survey_xlsx_to_prism_dataset))
+        self.assertTrue(callable(handlers.convert_survey_file_to_prism_dataset))
         self.assertTrue(callable(handlers.convert_survey_lsa_to_prism_dataset))
 
     def test_prepare_workflow_passes_through_blocking_confirmation(self):
@@ -592,7 +592,7 @@ class TestSurveyPrepareWorkflowEndpoint(unittest.TestCase):
             with (
                 patch.object(
                     handlers,
-                    "convert_survey_xlsx_to_prism_dataset",
+                    "convert_survey_file_to_prism_dataset",
                     object(),
                 ),
                 patch.object(
@@ -703,7 +703,7 @@ class TestSurveyPrepareWorkflowEndpoint(unittest.TestCase):
             with (
                 patch.object(
                     handlers,
-                    "convert_survey_xlsx_to_prism_dataset",
+                    "convert_survey_file_to_prism_dataset",
                     object(),
                 ),
                 patch.object(
@@ -782,7 +782,7 @@ class TestSurveyConvertPreviewEndpoint(unittest.TestCase):
             with (
                 patch.object(
                     handlers,
-                    "convert_survey_xlsx_to_prism_dataset",
+                    "convert_survey_file_to_prism_dataset",
                     object(),
                 ),
                 patch.object(
@@ -1070,7 +1070,7 @@ class TestSurveyConvertValidateEndpoint(unittest.TestCase):
             with (
                 patch.object(
                     handlers,
-                    "convert_survey_xlsx_to_prism_dataset",
+                    "convert_survey_file_to_prism_dataset",
                     object(),
                 ),
                 patch.object(
@@ -1180,7 +1180,7 @@ class TestSurveyConvertValidateEndpoint(unittest.TestCase):
             with (
                 patch.object(
                     handlers,
-                    "convert_survey_xlsx_to_prism_dataset",
+                    "convert_survey_file_to_prism_dataset",
                     object(),
                 ),
                 patch.object(
@@ -1290,7 +1290,7 @@ class TestSurveyConvertValidateEndpoint(unittest.TestCase):
 
             with patch.object(
                 handlers,
-                "convert_survey_xlsx_to_prism_dataset",
+                "convert_survey_file_to_prism_dataset",
                 object(),
             ), patch.object(
                 handlers,
@@ -1403,7 +1403,7 @@ class TestSurveyConvertValidateEndpoint(unittest.TestCase):
             with (
                 patch.object(
                     handlers,
-                    "convert_survey_xlsx_to_prism_dataset",
+                    "convert_survey_file_to_prism_dataset",
                     object(),
                 ),
                 patch.object(
@@ -1665,7 +1665,7 @@ class TestSurveyConverterImports(unittest.TestCase):
 
         module = importlib.import_module("src.converters.survey")
         self.assertIsNotNone(module)
-        self.assertTrue(hasattr(module, "convert_survey_xlsx_to_prism_dataset"))
+        self.assertTrue(hasattr(module, "convert_survey_file_to_prism_dataset"))
 
     def test_survey_template_loader_accepts_injected_kwargs(self):
         import importlib

--- a/tests/test_web_blueprints_conversion.py
+++ b/tests/test_web_blueprints_conversion.py
@@ -1667,6 +1667,17 @@ class TestSurveyConverterImports(unittest.TestCase):
         self.assertIsNotNone(module)
         self.assertTrue(hasattr(module, "convert_survey_file_to_prism_dataset"))
 
+    def test_conversion_survey_handlers_resolves_convert_function(self):
+        """The blueprint's module-level fallback (`= None`) must get overwritten
+        by the real converter on import, not silently stay None."""
+        import importlib
+
+        module = importlib.import_module(
+            "src.web.blueprints.conversion_survey_handlers"
+        )
+        self.assertIsNotNone(module.convert_survey_file_to_prism_dataset)
+        self.assertTrue(callable(module.convert_survey_file_to_prism_dataset))
+
     def test_survey_template_loader_accepts_injected_kwargs(self):
         import importlib
 


### PR DESCRIPTION
## Summary

Reworks Chapters 2-6 of the beginner tutorial (`docs/TUTORIAL_BEGINNER_*.md`) with more hands-on content in the spirit of the "PRISM without Panic" guide (ANC Salzburg, credited inline where content is directly adapted), after first auditing the backend each chapter documents per the `src/`/`app/src/` dual-tree-drift protocol in CLAUDE.md.

**Code audit result: already clean.** No live `src/` vs `app/src/` drift was found anywhere in the participants, survey-converter, recipe, validator, or project-manager code paths. The only code change is a cosmetic rename.

**Real bugs found and fixed** by actually running the backend against the tutorial's own fixtures rather than trusting the existing prose:
- **Chapter 6** told readers to open a freshly-cloned BIDS dataset via *Open Project*, which errors out (`Open Existing Project` requires a pre-existing `project.json`, which a plain BIDS clone doesn't have). Fixed to use *Init PRISM on BIDS Dataset* — and while verifying this against the real `ds003138` dataset, found that path can clone directly from a Git/DataLad URL (no manual terminal clone needed) and that the dataset already ships a populated `participants.tsv`, contradicting the chapter's old "no participants.tsv yet" premise. Rewrote Step 1 around Chapter 2's new Merge exercise instead of a from-scratch import that no longer matched reality.
- `wellbeing.tsv` was a stale 9-row snapshot of the 20-row `wellbeing.xlsx` (missing a `sleep` column) — regenerated it from the source. This also fixed Chapter 3's stale "5 participants found" preview claim (real answer: 20) and a wrong claim that Convert writes one JSON sidecar per participant (it actually writes one shared root-level sidecar per BIDS inheritance).

**Content added per chapter:**
- **Ch.2** — why the `session` column disappears from `participants.tsv`, the full ID auto-detect fallback chain, and a hands-on Merge-workflow exercise (Replace/Modify/Merge, conflict handling) that the chapter never covered before.
- **Ch.3** — retitled from "Import a Survey via Excel" to "Import Survey Response Data" since the converter accepts 8 formats, not just Excel; adds a CSV/TSV walkthrough variant and pointers to SPSS/R/LimeSurvey.
- **Ch.4** — documents "Min valid" and "Preview JSON" (real UI features, previously undocumented), plus the spreadsheet-vs-recipe scoring rationale.
- **Ch.5** — replaces the abstract error-code list with an actual worked example: cause a real `PRISM201` (missing sidecar) error, read it, clear it. Documents Pause/Resume/Cancel and Schema Version/Template Library Root.
- **Ch.6** — see bug fix above; also adds the `_fix_annexed_text_files` "why" narrative (real, tested, and directly relevant to this chapter's DataLad clone path).

Also includes one isolated, mechanical rename (not a behavior change): `convertExcelFile`/`convert_survey_xlsx_to_prism_dataset` → `convertSurveyFile`/`convert_survey_file_to_prism_dataset`, since those identifiers were named when Survey Import was Excel-only and are stale now that it accepts 8 formats.

## Test plan

- [x] 348 targeted tests pass across participants, recipe, validator, and project-manager subsystems
- [x] 339 tests pass covering the Chapter 3 rename specifically
- [x] `python tests/verify_repo.py --check dual-tree-drift --no-fix` — clean, no new drift introduced
- [x] Full Sphinx build (`python -m sphinx -b html . _build -W --keep-going`) — passes with warnings as errors
- [x] Every fact changed in Chapter 6 (subject IDs, session labels, participants.tsv contents, Init-on-BIDS behavior) verified against the real `ds003138` dataset on GitHub and/or the real backend, not assumed
- [x] Chapter 3's participant count and sidecar-structure claims verified by actually running `convert_survey_file_to_prism_dataset(dry_run=True)` and non-dry-run against the tutorial's own fixture
- [x] Chapter 5's PRISM201 worked example verified end-to-end against the real validator (`python prism.py`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)