### PR TITLE
fix: install sphinxcontrib-mermaid into docs/requirements.txt for RTD

### DIFF
--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -2,3 +2,4 @@
 sphinx
 shibuya
 myst-parser
+sphinxcontrib-mermaid


### PR DESCRIPTION
## Summary

Follow-up to #122. RTD build failed (https://app.readthedocs.org/api/v2/build/34351541.txt) with:

```
ModuleNotFoundError: No module named 'sphinxcontrib.mermaid'
```

`docs/conf.py` (merged in #122) added `sphinxcontrib.mermaid` to Sphinx's `extensions` list to render the new per-chapter tutorial diagrams, but the dependency was added to the repo-root `requirements-docs.txt` instead of `docs/requirements.txt` — the file RTD actually installs from, per `.readthedocs.yaml`:

```yaml
sphinx:
  configuration: docs/conf.py
python:
  install:
    - requirements: docs/requirements.txt
```

(`requirements-docs.txt` at the repo root isn't referenced by RTD or any CI workflow — grepped the whole repo to confirm.)

## Test plan

- [x] Verified locally with the exact command RTD runs: `python -m sphinx -T -W --keep-going -b html -d _build/doctrees -D language=en . <out>` — build succeeds, no errors.

🤖 Generated with [Claude Code](https://claude.com/claude-code)