### PR TITLE
Replace tutorial chapter flowcharts with input->tool->output diagrams

### DIFF
--- a/docs/TUTORIAL_BEGINNER_1_NEW_PROJECT.md
+++ b/docs/TUTORIAL_BEGINNER_1_NEW_PROJECT.md
@@ -11,12 +11,9 @@ belongs later in a study's lifecycle.
 correct folder structure and complete required metadata, ready for chapter 2.
 
 ```{mermaid}
-flowchart TD
-    A["Launch Studio"] --> B["Projects page:<br/>Create New Project"]
-    B --> C["Name & Location"]
-    C --> D["Study Metadata:<br/>Dataset Name, Authors, ..."]
-    D --> E["Create Project"]
-    E --> F["wellbeing_study/<br/>scaffold created"]
+flowchart LR
+    A["📁 An idea for a study<br/>nothing on disk yet"] --> B["🔧 Create New Project<br/>+ Study Metadata"]
+    B --> C["📁 wellbeing_study/<br/>correct structure,<br/>required metadata filled in"]
 ```
 
 <div class="prism-persona-note" data-persona-note>

--- a/docs/TUTORIAL_BEGINNER_2_PARTICIPANTS.md
+++ b/docs/TUTORIAL_BEGINNER_2_PARTICIPANTS.md
@@ -23,13 +23,9 @@ In this chapter, `participants.tsv` is a table with one row for each person.
 experience with PRISM's Merge workflow for updating them later.
 
 ```{mermaid}
-flowchart TD
-    A["Open wellbeing.xlsx<br/>(the source file)"] --> B["Reopen wellbeing_study<br/>(Project Manager)"]
-    B --> C["Converter →<br/>Sociodemographics tab"]
-    C --> D["Select file &<br/>ID column"]
-    D --> E["Review Participant<br/>Fields"]
-    E --> F["Create Participant<br/>Files"]
-    F -.optional later.-> G["Merge:<br/>update participants.tsv"]
+flowchart LR
+    A["📄 wellbeing.xlsx<br/>raw spreadsheet<br/>age, sex, education..."] --> B["🔧 Sociodemographics<br/>Converter"]
+    B --> C["📋 participants.tsv<br/>+ participants.json<br/>documented, ready to validate"]
 ```
 
 <div class="prism-persona-note" data-persona-note>

--- a/docs/TUTORIAL_BEGINNER_3_SURVEY_IMPORT.md
+++ b/docs/TUTORIAL_BEGINNER_3_SURVEY_IMPORT.md
@@ -18,16 +18,9 @@ Archive) — see the format note in Part B, step 3.
 participant, written into subject-level folders under `wellbeing_study`.
 
 ```{mermaid}
-flowchart TD
-    A["Part A: get a template"] --> B{"Already have one?"}
-    B -->|"Yes, ready-made"| C["Copy survey-wellbeing.json"]
-    B -->|"No, build your own"| D["Excel Template Basics"]
-    C --> E["Part B: Converter → Survey"]
-    D --> E
-    E --> F["Choose source file"]
-    F --> G["Confirm mapping:<br/>ID, Session"]
-    G --> H["Preview (dry-run)"]
-    H --> I["Convert"]
+flowchart LR
+    A["📄 wellbeing.xlsx<br/>WB01-WB05 responses<br/>+ a survey template"] --> B["🔧 Survey<br/>Converter"]
+    B --> C["📋 One survey.tsv<br/>per participant<br/>+ shared sidecar JSON"]
 ```
 
 <div class="prism-persona-note" data-persona-note>

--- a/docs/TUTORIAL_BEGINNER_4_RECIPE.md
+++ b/docs/TUTORIAL_BEGINNER_4_RECIPE.md
@@ -10,13 +10,9 @@ separate page, covered in step 5 below.
 `wellbeing` survey, and a computed total score for every participant.
 
 ```{mermaid}
-flowchart TD
-    A["Open Recipe Builder"] --> B["Pick modality & template"]
-    B --> C["Reverse coding<br/>(skip if not needed)"]
-    C --> D["Build the score:<br/>Item Pool → Add Scale"]
-    D --> E["Variations<br/>(skip if one form)"]
-    E --> F["Metadata & Save"]
-    F --> G["Export / Analysis Output:<br/>run the recipe"]
+flowchart LR
+    A["📊 WB01-WB05<br/>item responses<br/>(kept as-is, untouched)"] --> B["🔧 Recipe Builder<br/>a saved scoring rule"]
+    B --> C["📈 Computed total score<br/>per participant<br/>re-runnable, never overwrites raw data"]
 ```
 
 <div class="prism-persona-note" data-persona-note>

--- a/docs/TUTORIAL_BEGINNER_5_VALIDATOR.md
+++ b/docs/TUTORIAL_BEGINNER_5_VALIDATOR.md
@@ -10,14 +10,9 @@ which will vary by project.
 and enough understanding of the results to know what to do next.
 
 ```{mermaid}
-flowchart TD
-    A["Open the Validator"] --> B["Leave Advanced Options<br/>at defaults"]
-    B --> C["Start Validation"]
-    C --> D["Read the results"]
-    D --> E["Fix an issue"]
-    E --> F["Re-validate"]
-    F -->|"issues remain"| D
-    F -->|"clean"| G["Done"]
+flowchart LR
+    A["📁 wellbeing_study<br/>as built so far"] --> B["🔧 Validator<br/>PRISM + BIDS checks"]
+    B --> C["✅ Findings read & fixed<br/>a dataset you can trust"]
 ```
 
 <div class="prism-persona-note" data-persona-note>

--- a/docs/TUTORIAL_BEGINNER_6_EXISTING_BIDS.md
+++ b/docs/TUTORIAL_BEGINNER_6_EXISTING_BIDS.md
@@ -5,10 +5,9 @@ real published BIDS dataset, cloned and initialized without a manual
 terminal step, enriched with PRISM participant and behavioral metadata
 
 ```{mermaid}
-flowchart TD
-    A["Init PRISM on BIDS Dataset:<br/>Git/DataLad URL"] --> B["Step 1: Merge into<br/>existing participants.tsv"]
-    B --> C["Step 2: add survey data<br/>(Converter → Survey)"]
-    C --> D["Step 3: Validate"]
+flowchart LR
+    A["🧠 ds003138<br/>existing BIDS dataset<br/>MRI data, no PRISM layer"] --> B["🔧 Init PRISM +<br/>Merge + Survey Import"]
+    B --> C["📋 Same dataset,<br/>enriched with<br/>PRISM metadata"]
 ```
 
 ## Why enrich existing datasets?


### PR DESCRIPTION
## Summary

Follow-up to #122 based on feedback that the per-chapter step flowcharts looked "too technical" and weren't adding much beyond the numbered steps already in the prose right below them.

Replaces all 6 chapter diagrams with one consistent 3-node shape: **source data/state → the PRISM tool → structured result**. Same shape in every chapter, so readers learn to recognize it once and it reads as a mental model (what turns into what, and why) rather than a UI click-path restated as boxes.

| Chapter | Input | Tool | Output |
|---|---|---|---|
| 1 | An idea for a study | Create New Project + Study Metadata | `wellbeing_study/` scaffold |
| 2 | `wellbeing.xlsx` raw spreadsheet | Sociodemographics Converter | `participants.tsv` + `.json` |
| 3 | `wellbeing.xlsx` responses + template | Survey Converter | Per-participant `survey.tsv` + shared sidecar |
| 4 | `WB01`-`WB05` item responses | Recipe Builder | Saved recipe + computed score |
| 5 | Project as built so far | Validator | Findings read & fixed |
| 6 | ds003138 (existing BIDS, no PRISM layer) | Init PRISM + Merge + Survey Import | Same dataset, enriched |

## Test plan

- [x] Full Sphinx build with the exact RTD command (`python -m sphinx -T -W --keep-going -b html ...`) — succeeds, no warnings
- [x] Confirmed exactly one `class="mermaid"` diagram renders per chapter, no duplicates or leftovers

🤖 Generated with [Claude Code](https://claude.com/claude-code)